### PR TITLE
feat: attachments

### DIFF
--- a/ai_eval/static/js/src/shortanswer_edit.js
+++ b/ai_eval/static/js/src/shortanswer_edit.js
@@ -1,0 +1,101 @@
+/* Javascript for ShortAnswerAIEvalXBlock. */
+function ShortAnswerAIEvalXBlock(runtime, element) {
+    "use strict";
+
+    StudioEditableXBlockMixin(runtime, element);
+
+    var viewAttachmentUrl = runtime.handlerUrl(element, "view_attachment");
+
+    var $input = $('#xb-field-edit-attachments');
+
+    var buildFileInput = function() {
+        var $wrapper = $('<div id="attachments-wrapper" class="wrapper-list-settings"/>');
+
+        var $fileList = $('<ul class="list-settings list-set"/>');
+        var files = JSON.parse($input.val() || "{}");
+        for (var filename of Object.keys(files)) {
+            var $fileItem = $('<li class="list-settings-item"/>');
+            var $fileLink;
+            if (files[filename] === null) {
+                /* File that already exists. */
+                $fileLink = $('<a/>');
+                $fileLink.attr("target", "_blank");
+                var fileLinkQuery = new URLSearchParams({key: filename}).toString();
+                $fileLink.attr('href', `${viewAttachmentUrl}?${fileLinkQuery}`);
+            } else {
+                $fileLink = $('<span/>');
+            }
+            $fileLink.append(filename);
+            $fileItem.append($fileLink);
+            var $deleteButton = $('<button class="action" type="button"/>');
+            $deleteButton.append($('<i class="icon fa fa-trash"/>'));
+            var $deleteButtonText = $('<span class="sr"/>');
+            $deleteButtonText.append(gettext("Delete file"));
+            $deleteButton.append($deleteButtonText);
+            $deleteButton.data("attachment-name", filename);
+            $deleteButton.click(deleteAttachment);
+            $fileItem.append($deleteButton);
+            $fileList.append($fileItem);
+        }
+        $wrapper.append($fileList);
+
+        var $fileInput = $('<input type="file"/>');
+        $wrapper.append($fileInput);
+
+        var $uploadButton = $('<button class="action" type="button"/>');
+        $uploadButton.append($('<i class="icon fa fa-upload"/>'));
+        $uploadButton.click(addAttachment);
+        var $uploadButtonText = $('<span class="sr"/>');
+        $uploadButtonText.append(gettext("Upload file"));
+        $uploadButton.append($uploadButtonText);
+        $wrapper.append($uploadButton);
+
+        var $oldWrapper = $('#attachments-wrapper');
+        if ($oldWrapper.length) {
+            $input.closest('li').addClass('is-set');
+            $oldWrapper.replaceWith($wrapper);
+        } else {
+            $input.hide();
+            $wrapper.insertBefore($input);
+        }
+    }
+
+    var deleteAttachment = function() {
+        var $button = $(this);
+
+        var files = JSON.parse($input.val());
+        delete files[$button.data("attachment-name")];
+        $input.val(JSON.stringify(files));
+
+        buildFileInput();
+    }
+
+    var insertAttachment = function(files, filename, data) {
+        var foundFilename = filename;
+        var i = 0;
+        while (Object.prototype.hasOwnProperty.call(files, foundFilename)) {
+            i++;
+            foundFilename = `${filename} (${i})`;
+        }
+        files[foundFilename] = data;
+    }
+
+    var addAttachment = function() {
+        var $button = $(this);
+        var $fileInput = $button.prev('input[type="file"]');
+        var file = $fileInput[0].files[0];
+
+        if (file !== undefined) {
+            var reader = new FileReader();
+            reader.onload = function(e) {
+                var files = JSON.parse($input.val());
+                insertAttachment(files, file.name, e.target.result);
+                $input.val(JSON.stringify(files));
+                buildFileInput();
+            }
+            reader.readAsText(file);
+        }
+    }
+
+    buildFileInput();
+}


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable. If your linked information must be private (because it has secrets),
clearly label the link as private.
-->

## Description

Adds text attachments to the short answer AI XBlock that can provide additional context to the LLM.

## Testing instructions

1. Add an attachment in XBlock settings.
2. Save settings.
3. Open settings again.
4. Download the attachment.
5. Remove the attachment.
6. Add another attachment.
7. Save settings.
8. Publish the module.
9. View it as a learner.
10. Write a message ask about the contents of the attachment by name.
11. See that the LLM is able to tell you about the contents.

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-9244