### PR TITLE
feat: character image in short answer XBlock

### DIFF
--- a/ai_eval/shortanswer.py
+++ b/ai_eval/shortanswer.py
@@ -30,6 +30,15 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         scope=Scope.settings,
     )
 
+    character_image = String(
+        display_name=_("Character Image URL"),
+        help=_(
+            "URL for an image to be shown to the left of the chat box; "
+            "leave empty to disable"
+        ),
+        scope=Scope.settings,
+    )
+
     max_responses = Integer(
         display_name=_("Max Responses"),
         help=_("The maximum number of response messages the student can submit"),
@@ -47,6 +56,7 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
     editable_fields = AIEvalXBlock.editable_fields + (
         "max_responses",
         "allow_reset",
+        "character_image",
     )
 
     def validate_field_data(self, validation, data):

--- a/ai_eval/static/css/shortanswer.css
+++ b/ai_eval/static/css/shortanswer.css
@@ -1,5 +1,15 @@
 /* CSS for ShortAnswerAIEvalXBlock */
 
+.shortanswer_image {
+  float: left;
+  margin-right: 4rem;
+  width: 30%;
+}
+
+.shortanswer_image > img {
+  max-width: 100%;
+}
+
 .shortanswer_block .count {
   font-weight: bold;
 }

--- a/ai_eval/templates/shortanswer.html
+++ b/ai_eval/templates/shortanswer.html
@@ -1,3 +1,9 @@
+{% if self.character_image %}
+    <div class="shortanswer_image">
+        <img src="{{ self.character_image }}" />
+    </div>
+{% endif %}
+
 <div class="shortanswer_block">
     <div>
         <div id="question-text">

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -85,3 +85,13 @@ class TestShortAnswerAIEvalXBlock(unittest.TestCase):
         with self.assertRaises(JsonHandlerError):
             block.reset.__wrapped__(block, data={})
         self.assertEqual(block.messages, {"USER": ["Hello"], "LLM": ["Hello"]})
+
+    def test_character_image(self):
+        """Test the character image."""
+        data = {
+            **self.data,
+            "character_image": "/static/image.jpg",
+        }
+        block = ShortAnswerAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
+        frag = block.student_view()
+        self.assertIn('<img src="/static/image.jpg" />', frag.content)


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable. If your linked information must be private (because it has secrets),
clearly label the link as private.
-->

## Description

Adds an optional, configurable image to the left of the short answer XBlock, representing a character the learner is dialoguing with.

![image](https://github.com/user-attachments/assets/87d8b94e-035c-4b48-aca3-c171dafdfb69)

## Testing instructions

1. Set "Character Image URL" in the XBlock settings
2. See that it works

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-9245