### PR TITLE
feat: allow attaching files by URL to the short answer XBlock

### DIFF
--- a/ai_eval/__init__.py
+++ b/ai_eval/__init__.py
@@ -4,3 +4,4 @@ Xblock to have short text and code entries with AI-driven evaluation.
 
 from .shortanswer import ShortAnswerAIEvalXBlock
 from .coding_ai_eval import CodingAIEvalXBlock
+from .multiagent import MultiAgentAIEvalXBlock

--- a/ai_eval/multiagent.py
+++ b/ai_eval/multiagent.py
@@ -1,0 +1,636 @@
+"""Multi-agent AI XBlock."""
+
+import itertools
+import re
+import textwrap
+import typing
+
+import jinja2
+import pydantic
+from django.utils.translation import gettext_noop as _
+from jinja2.sandbox import SandboxedEnvironment
+from xblock.core import XBlock
+from xblock.exceptions import JsonHandlerError
+from xblock.fields import Boolean, Dict, List, Scope, String
+from xblock.validation import ValidationMessage
+from web_fragments.fragment import Fragment
+
+from .base import AIEvalXBlock
+from .llm import SupportedModels
+
+
+DEFAULT_SUPERVISOR_PROMPT = textwrap.dedent("""
+    You are a supervisor managing an interaction between the following agents: Coach, Character.
+    Based on the conversation, decide which agent should respond next.
+    You can choose from: Character, Coach, or FINISH.
+    You are responsible for managing the flow of the conversation between agents.
+    The conversation should flow naturally with the Character until specific conditions are met.
+    Switch control to the Coach only under the following conditions:
+    (1) The learner makes the same mistake **three times in a row**.
+    (2) The learner **explicitly** asks for help.
+    (3) The learner gets **significantly off topic** and is no longer addressing the learning objectives or the project.
+    If the learner shows minor deviations or uncertainty, let the Character continue interacting with the learner.
+    And if the learner specifically asks for help, you should always call on the Coach.
+    Your goal is to provide enough opportunities for the learner to self-correct and progress naturally without premature intervention.
+    Call the conversation complete and choose FINISH only under the following conditions:
+    (1) The **learning objectives and evaluation criteria are fully met**,
+    (2) The learner explicitly indicates they are done with the conversation, or
+    (3) Progress **stalls** and it becomes evident that the learner cannot achieve the learning objectives after multiple attempts.
+    Always finish the conversation when the learner requests.
+    If the interaction is complete, choose 'FINISH'.
+    Learning Objectives: {{ scenario_data.scenario.learning_objectives }}
+    Evaluation Criteria: {{ scenario_data.evaluation_criteria }}
+
+    Who should act next? Do not give an explanation. Output exactly and only one option.
+    Choose from: ['Character', 'Coach', 'FINISH']
+""").strip()  # noqa
+
+
+DEFAULT_AGENT_PROMPT = textwrap.dedent("""
+    You are {{ character_name }}.
+    In the given conversation, you are speaking to {{ user_character_name }}, who is described as: {{ user_character_data }}.
+
+    {% if character_data %}
+        Personality details: {{ character_data.professional_summary }}
+        Key competencies: {{ character_data.key_competencies }}
+        Behavioral profile: {{ character_data.behavioral_profile }}
+    {% endif %}
+
+    {% if role == "Coach" %}
+        Learning Objectives: {{ scenario_data.scenario.learning_objectives }}
+        Evaluation Criteria: {{ scenario_data.evaluation_criteria }}
+    {% endif %}
+
+    Case Details: {{ scenario_data.scenario.case_details }}.
+
+    {% for agent in scenario_data.agents %}
+        {% if role.lower() == agent.role %}
+            {{ agent.instructions }}
+        {% endif %}
+    {% endfor %}
+    Speak in a dialogue fashion, naturally and succinctly.
+    Do not do the work for the student. If the student tries to get you to answer the questions you are asking them to supply information on, redirect them to the task.
+    Do not present tables, lists, or detailed written explanations. For instance, do not say 'the main goals include: 1. ...'
+    Output only the text content of the next message from {{ character_name }}.
+""").strip()  # noqa
+
+
+DEFAULT_EVALUATOR_PROMPT = textwrap.dedent("""
+    You are an evaluator agent responsible for generating an evaluation report of the conversation after the conversation has concluded.
+    Use the provided chat history to evaluate the learner based on the evaluation criteria.
+    You are evaluating the user based on their input, not the reactions by the other characters (such as the main character or the coach).
+    **Important**: Your only job is to give an evaluation report in well-structured markdown. You are not to chat with the learner. Do not engage in any conversation or provide feedback directly to the user. Do not ask questions, give advice or encouragement, or continue the conversation. Your only job is to produce the evaluation report.
+    Your task is to produce a well-structured markdown report in the following format:
+
+    # Evaluation Report
+
+    {% for criterion in scenario_data.evaluation_criteria %}
+        ## {{ criterion.name }}
+        ### Score: (0-5)/5
+        **Rationale**: Provide a rationale for the score, using specific direct quotes from the conversation as evidence.
+    {% endfor %}
+
+    Your response must adhere to this exact structure, and each score must have a detailed rationale that includes at least one direct quote from the chat history.
+    If you cannot find a direct quote, mention this explicitly and provide an explanation.
+""").strip()  # noqa
+
+
+DEFAULT_CONVERSATION_FORMAT = textwrap.dedent("""
+    <conversation>
+        {% for message in messages %}
+            <message>
+                <agent>{{ message.agent }}</agent>
+                <name>{{ message.name }}</name>
+                <role>{{ message.role }}</role>
+                <content>{{ message.content | escape }}</content>
+            </message>
+        {% endfor %}
+    </conversation>
+""")
+
+
+class Scenario(pydantic.BaseModel):
+    title: str
+    initial_message: str
+
+
+class ScenarioCharacters(pydantic.BaseModel):
+    user_character: str
+
+
+class ScenarioData(pydantic.BaseModel):
+    scenario: Scenario
+    characters: ScenarioCharacters
+
+
+class Character(pydantic.BaseModel):
+    name: str
+    role: str
+
+
+class CharacterData(pydantic.BaseModel):
+    characters: typing.List[Character]
+
+
+class MultiAgentAIEvalXBlock(AIEvalXBlock):
+    """
+
+    AI-powered XBlock for simulated conversations with
+    multiple agents and custom scenarios.
+
+    """
+
+    _jinja_env = SandboxedEnvironment(undefined=jinja2.StrictUndefined)
+
+    MAIN_CHARACTER_KEY = "main_character"
+    USER_CHARACTER_KEY = "user_character"
+
+    display_name = String(
+        display_name=_("Display Name"),
+        help=_("Name of the component in the studio"),
+        default="Multi-agent AI Evaluation",
+        scope=Scope.settings,
+    )
+
+    supervisor_prompt = String(
+        display_name=_("Supervisor prompt"),
+        help=_(
+            'Prompt used to instruct the model how to choose the next agent. '
+            'Instruct it to choose between one of the roles in "Role '
+            'characters" or the command specified in "Supervisor finish '
+            'command".'
+        ),
+        multiline_editor=True,
+        default=DEFAULT_SUPERVISOR_PROMPT,
+        scope=Scope.settings,
+    )
+
+    finish_command = String(
+        display_name=_("Supervisor finish command"),
+        help=_("Output from the Supervisor to be recognised as end of session"),
+        scope=Scope.settings,
+        default=_("FINISH"),
+    )
+
+    supervisor_prefill = String(
+        display_name=_("Prefill for supervisor reply"),
+        help=_("Prefill used to hint the model when acting as the Supervisor"),
+        scope=Scope.settings,
+        default=_("Choice: "),
+    )
+
+    role_characters = Dict(
+        display_name=_("Agent characters"),
+        help=_(
+            "Mapping of agents used by the Supervisor to character keys "
+            "in scenario data"
+        ),
+        scope=Scope.settings,
+        default={
+            _("User"): USER_CHARACTER_KEY,
+            _("Character"): MAIN_CHARACTER_KEY,
+            _("Coach"): "coach",
+        },
+    )
+
+    agent_prompt = String(
+        display_name=_("Agent prompt"),
+        help=_(
+            "Prompt used to instruct the model how to act as an agent. "
+            "Template variables available are: role, scenario_data, "
+            "character_data, character_name, user_character_data, "
+            "user_character_name"
+        ),
+        multiline_editor=True,
+        default=DEFAULT_AGENT_PROMPT,
+        scope=Scope.settings,
+    )
+
+    evaluator_prompt = String(
+        display_name=_("Evaluator prompt"),
+        help=_(
+            "Prompt used to instruct the model how to evaluate the learner"
+        ),
+        multiline_editor=True,
+        default=DEFAULT_EVALUATOR_PROMPT,
+        scope=Scope.settings,
+    )
+
+    conversation_format = String(
+        display_name=_("Conversation format template"),
+        help=_(
+            "Template used to format the conversation, appended to all prompts"
+        ),
+        multiline_editor=True,
+        default=DEFAULT_CONVERSATION_FORMAT,
+        scope=Scope.settings,
+    )
+
+    message_content_tag = String(
+        display_name=_("Message content tag"),
+        help=_("Tag for finding message content in the model's response"),
+        default="content",
+        scope=Scope.settings,
+    )
+
+    scenario_data = Dict(
+        scope=Scope.settings,
+        default={
+            "scenario": {
+                "title": "",
+                "initial_message": "",
+                "case_details": "",
+                "learning_objectives": [],
+            },
+            "evaluation_criteria": [],
+            "characters": {
+                USER_CHARACTER_KEY: "Alex",
+                MAIN_CHARACTER_KEY: "Jack",
+                "coach": "Maya",
+            },
+            "agents": [],
+        }
+    )
+
+    character_data = Dict(
+        scope=Scope.settings,
+        default={
+            "characters": [],
+        }
+    )
+
+    allow_reset = Boolean(
+        display_name=_("Allow reset"),
+        help=_("Allow the learner to reset the chat"),
+        scope=Scope.settings,
+        default=True,
+    )
+
+    blacklist = List(
+        display_name=_("Output blacklist"),
+        help=_(
+            "List of words that, if present in the AI response, "
+            "will cause the message to not be shown to the learner, "
+            "displaying an error instead"
+        ),
+        scope=Scope.settings,
+        # Prevent the LLM from breaking character and calling itself an AI
+        # assistant if the user tries to do subvert the plot.
+        default=["AI assistant"],
+    )
+
+    finished = Boolean(
+        scope=Scope.user_state,
+        default=False,
+    )
+
+    chat_history = List(
+        scope=Scope.user_state,
+        default=[],
+    )
+
+    editable_fields = AIEvalXBlock.editable_fields + (
+        "scenario_data",
+        "character_data",
+        "supervisor_prompt",
+        "supervisor_prefill",
+        "role_characters",
+        "finish_command",
+        "agent_prompt",
+        "evaluator_prompt",
+        "allow_reset",
+        "blacklist",
+    )
+
+    def _render_template(self, template, **context):
+        return self._jinja_env.from_string(template).render(context)
+
+    def _get_character(self, key):
+        """For a given character key, get its agent and character data."""
+        for agent, k in self.role_characters.items():
+            if k == key:
+                name = self.scenario_data["characters"].get(key)
+                data = self._get_character_data(name)
+                return agent, data
+        return "", {}
+
+    def _llm_input(self, prompt, user_input):
+        """Append the chat history to the given system prompt."""
+        main_agent, main_data = self._get_character(self.MAIN_CHARACTER_KEY)
+        user_agent, user_data = self._get_character(self.USER_CHARACTER_KEY)
+        initial_messages = []
+        if self.scenario_data["scenario"]["initial_message"]:
+            initial_messages.append({
+                "role": "assistant",
+                "content": self.scenario_data["scenario"]["initial_message"],
+                "extra": {
+                    "role": main_agent,
+                    "character_data": main_data,
+                },
+            })
+        user_message = {
+            "role": "user",
+            "content": user_input,
+        }
+        chat_history = []
+        # For legacy reasons, stored chat history has the format of a chat
+        # history with an LLM completion, with each message having a "role"
+        # of "user" or "assistant".
+        for message in itertools.chain(initial_messages,
+                                       self.chat_history,
+                                       [user_message]):
+            if message["role"] == "assistant":
+                agent = message["extra"].get("role") or ""
+                character_data = message["extra"].get("character_data") or {}
+            else:
+                agent = user_agent
+                character_data = user_data
+            chat_history.append({
+                "content": message["content"],
+                "agent": agent,
+                "name": character_data.get("name", ""),
+                "role": character_data.get("role", ""),
+            })
+        prompt += "\n\n" + self._render_template(
+            self.conversation_format,
+            messages=chat_history,
+        )
+        yield {"role": "system", "content": prompt}
+        if self.model == SupportedModels.CLAUDE_SONNET.value:
+            # Claude needs a dummy user reply before the first
+            # assistant reply.
+            yield {"role": "user", "content": "."}
+
+    def _get_field_display_name(self, field_name):
+        return self.fields[field_name].display_name
+
+    def validate_field_data(self, validation, data):
+        """Validate field data."""
+        super().validate_field_data(validation, data)
+
+        try:
+            ScenarioData(**data.scenario_data)
+        except pydantic.ValidationError as e:
+            for error in e.errors():
+                field = error["loc"][0]
+                msg = error["msg"]
+                validation.add(ValidationMessage(
+                    ValidationMessage.ERROR,
+                    (
+                        f"{self._get_field_display_name('scenario_data')}: "
+                        f"{field!r}: {msg}"
+                    ),
+                ))
+        try:
+            CharacterData(**data.character_data)
+        except pydantic.ValidationError as e:
+            for error in e.errors():
+                field = error["loc"][0]
+                msg = error["msg"]
+                validation.add(ValidationMessage(
+                    ValidationMessage.ERROR,
+                    (
+                        f"{self._get_field_display_name('character_data')}: "
+                        f"{field!r}: {msg}"
+                    ),
+                ))
+
+        for prompt_field in ['supervisor_prompt', 'evaluator_prompt']:
+            try:
+                self._render_template(getattr(data, prompt_field),
+                                      scenario_data=data.scenario_data)
+            except jinja2.TemplateError as e:
+                validation.add(ValidationMessage(
+                    ValidationMessage.ERROR,
+                    f"{self._get_field_display_name(prompt_field)}: {e}",
+                ))
+
+        # pylint: disable=too-many-nested-blocks
+        try:
+            self._render_template(
+                data.agent_prompt,
+                role="",
+                character_name="",
+                character_data=None,
+                user_character_name="",
+                user_character_data="",
+                scenario_data=data.scenario_data,
+            )
+        except jinja2.TemplateError as e:
+            validation.add(ValidationMessage(
+                ValidationMessage.ERROR,
+                f"{self._get_field_display_name('agent_prompt')}: {e}",
+            ))
+        else:
+            chars = data.character_data.get("characters", [])
+            for i, char_data in enumerate(chars):
+                # Character name is validated above but may be missing yet.
+                char_name = char_data.get("name", "")
+                role = ""
+                for key, name in data.scenario_data.get("characters",
+                                                        {}).items():
+                    if name == char_name:
+                        for r, k in data.role_characters.items():
+                            if k == key:
+                                role = r
+                                break
+                        break
+                try:
+                    self._render_template(
+                        data.agent_prompt,
+                        role=role,
+                        character_name=char_name,
+                        character_data=char_data,
+                        user_character_name="",
+                        user_character_data="",
+                        scenario_data=data.scenario_data,
+                    )
+                except jinja2.TemplateError as e:
+                    validation.add(ValidationMessage(
+                        ValidationMessage.ERROR,
+                        (
+                            f"{self._get_field_display_name('agent_prompt')}/"
+                            f"{self._get_field_display_name('character_data')}"
+                            f"[{i}]: {e}"
+                        ),
+                    ))
+
+    def student_view(self, context=None):
+        """
+        The primary view of the MultiAgentAIEvalXBlock, shown to students
+        when viewing courses.
+        """
+
+        frag = Fragment()
+        scenario = self.scenario_data['scenario']
+        frag.add_content(
+            self.loader.render_django_template(
+                "/templates/chatbox.html",
+                {
+                    "self": self,
+                    "has_finish_button": True,
+                    "question_text": f"<h3><b>{scenario['title']}</b></h3>",
+                },
+            )
+        )
+        frag.add_css(self.resource_string("static/css/chatbox.css"))
+        frag.add_javascript(self.resource_string("static/js/src/utils.js"))
+        frag.add_javascript(self.resource_string("static/js/src/chatbox.js"))
+        frag.add_javascript(self.resource_string("static/js/src/multiagent.js"))
+        marked_html = self.resource_string("static/html/marked-iframe.html")
+        main_agent = ""
+        main_name = ""
+        main_data = {}
+        for agent, key in self.role_characters.items():
+            if key == self.MAIN_CHARACTER_KEY:
+                main_agent = agent
+                main_name = self._get_character_name(agent)
+                main_data = self._get_character_data(main_name)
+                break
+        js_data = {
+            "messages": self.chat_history,
+            "main_character_agent": main_agent,
+            "main_character_data": {
+                "name": main_data.get("name", main_name),
+                "role": main_data.get("role", ""),
+            },
+            "initial_message": scenario["initial_message"],
+            "finished": self.finished,
+            "marked_html": marked_html,
+        }
+        frag.initialize_js("MultiAgentAIEvalXBlock", js_data)
+        return frag
+
+    def _get_next_agent(self, user_input):
+        """Use the LLM to decide which agent should respond to the user."""
+        prompt = self._render_template(self.supervisor_prompt,
+                                       scenario_data=self.scenario_data)
+        messages = list(self._llm_input(prompt, user_input))
+        if self.model == SupportedModels.CLAUDE_SONNET.value:
+            if self.supervisor_prefill:
+                messages.append({"role": "assistant",
+                                 "content": self.supervisor_prefill})
+        response = self.get_llm_response(messages).strip()
+
+        choices = list(itertools.chain(self.role_characters.keys(),
+                                       [self.finish_command]))
+        m = re.search(fr"\b({'|'.join(map(re.escape, choices))})\b",
+                      response, re.I)
+        if not m:
+            raise RuntimeError(f"bad response {response!r}")
+        found = m.group(1)
+        for choice in choices:
+            if choice.lower() == found.lower():
+                return choice
+
+        # Should not be reached.
+        raise RuntimeError("unknown error")
+
+    def _get_character_name(self, agent):
+        """Get character name from agent name (supervisor choice)."""
+        if agent == self.finish_command:
+            return None
+        key = self.role_characters[agent]
+        return self.scenario_data["characters"][key]
+
+    def _get_character_data(self, character_name):
+        """Get character data from character name."""
+        for character_data in self.character_data["characters"]:
+            if character_data["name"] == character_name:
+                return character_data
+        return {}
+
+    def _get_agent_response(self, agent, user_input):
+        """
+
+        Use the LLM to generate a message from the given agent in the scenario.
+
+        """
+        user_name = self.scenario_data["characters"][self.USER_CHARACTER_KEY]
+        user_data = self._get_character_data(user_name)
+        character_name = self._get_character_name(agent)
+        character_data = self._get_character_data(character_name)
+        prompt = self._render_template(
+            self.agent_prompt,
+            scenario_data=self.scenario_data,
+            role=agent,
+            character_data=character_data,
+            character_name=character_name,
+            user_character_data=user_data,
+            user_character_name=user_name,
+        )
+        messages = list(self._llm_input(prompt, user_input))
+        response = self.get_llm_response(messages)
+        if self.blacklist:
+            if re.search(fr"\b({'|'.join(map(re.escape, self.blacklist))})\b",
+                         response, re.I):
+                raise JsonHandlerError(500, "Internal error.")
+        if self.message_content_tag:
+            m = re.search((fr'<{re.escape(self.message_content_tag)}>(.*)'
+                           fr'</{re.escape(self.message_content_tag)}>'),
+                          response)
+            if m:
+                response = m.group(1)
+        return response
+
+    def _get_evaluator_response(self, user_input):
+        """Get the response from the special "Evaluator" agent."""
+        prompt = self._render_template(self.evaluator_prompt,
+                                       scenario_data=self.scenario_data)
+        messages = list(self._llm_input(prompt, user_input))
+        response = self.get_llm_response(messages)
+        return response
+
+    @XBlock.json_handler
+    def get_response(self, data, suffix=""):  # pylint: disable=unused-argument
+        """Generate the next message in the interaction."""
+        # We use the LLM twice here: one time to decide which character to use,
+        # and one time to act as that character.
+
+        if self.finished:
+            raise JsonHandlerError(403, "The session has ended.")
+
+        if data.get("force_finish", False):
+            user_input = ""
+            agent = None
+            is_evaluator = True
+        else:
+            user_input = str(data["user_input"])
+            agent = self._get_next_agent(user_input)
+            is_evaluator = agent == self.finish_command
+
+        if is_evaluator:
+            message = self._get_evaluator_response(user_input)
+            self.finished = True
+            character_data = {}
+        else:
+            message = self._get_agent_response(agent, user_input)
+            character_name = self._get_character_name(agent)
+            character_data = self._get_character_data(character_name)
+            character_data = character_data.copy()
+            character_data.setdefault("name", character_name)
+
+        self.chat_history.append({"role": "user", "content": user_input})
+        extra = {"is_evaluator": is_evaluator, "role": agent,
+                 "character_data": character_data}
+        self.chat_history.append({"role": "assistant", "content": message,
+                                  "extra": extra})
+        return {
+            "message": message,
+            "finished": self.finished,
+            "is_evaluator": is_evaluator,
+            "role": agent,
+            "character_data": {
+                "name": character_data.get("name", ""),
+                "role": character_data.get("role", ""),
+            },
+        }
+
+    @XBlock.json_handler
+    def reset(self, data, suffix=""):
+        """Reset the chat history."""
+        if not self.allow_reset:
+            raise JsonHandlerError(403, "Reset is disabled.")
+        self.chat_history = []
+        self.finished = False
+        return {}

--- a/ai_eval/multiagent.py
+++ b/ai_eval/multiagent.py
@@ -302,6 +302,21 @@ class MultiAgentAIEvalXBlock(AIEvalXBlock):
         "blacklist",
     )
 
+    def studio_view(self, context):
+        """
+        Render a form for editing this XBlock
+        """
+        fragment = super().studio_view(context)
+        fragment.add_javascript(self.resource_string("static/js/src/multiagent_edit.js"))
+        jsoneditor_html = self.resource_string("static/html/jsoneditor-iframe.html")
+        js_data = {
+            'jsoneditor_html': jsoneditor_html,
+        }
+        # MultiAgentAIEvalXBlock() in multiagent_edit.js will call
+        # StudioEditableXBlockMixin().
+        fragment.initialize_js("MultiAgentAIEvalXBlock", js_data)
+        return fragment
+
     def _render_template(self, template, **context):
         return self._jinja_env.from_string(template).render(context)
 

--- a/ai_eval/shortanswer.py
+++ b/ai_eval/shortanswer.py
@@ -2,13 +2,16 @@
 
 import logging
 import traceback
-
+import urllib.parse
+import urllib.request
+from multiprocessing.dummy import Pool
+from xml.sax import saxutils
 
 from django.utils.translation import gettext_noop as _
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
-from xblock.fields import Boolean, Dict, Integer, String, Scope
+from xblock.fields import Boolean, Dict, Integer, List, String, Scope
 from xblock.validation import ValidationMessage
 
 from .base import AIEvalXBlock
@@ -24,6 +27,7 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
 
     USER_KEY = "USER"
     LLM_KEY = "LLM"
+    ATTACHMENT_PARALLEL_DOWNLOADS = 5
 
     display_name = String(
         display_name=_("Display Name"),
@@ -84,12 +88,20 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         default={USER_KEY: [], LLM_KEY: []},
     )
 
+    attachment_urls = List(
+        display_name=_("Attachment URLs"),
+        help=_("Attachments to include with the evaluation prompt"),
+        scope=Scope.settings,
+        resettable_editor=False,
+    )
+
     editable_fields = AIEvalXBlock.editable_fields + (
         "question",
         "evaluation_prompt",
         "max_responses",
         "allow_reset",
         "character_image",
+        "attachment_urls",
     )
 
     def validate_field_data(self, validation, data):
@@ -148,19 +160,45 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         frag.initialize_js("ShortAnswerAIEvalXBlock", js_data)
         return frag
 
+    def _download_attachment(self, url):
+        with urllib.request.urlopen(url) as f:
+            return f.read().decode('utf-8')
+
+    def _filename_for_url(self, url):
+        return urllib.parse.urlparse(url).path.split('/')[-1]
+
+    def _get_attachments(self):
+        pool = Pool(self.ATTACHMENT_PARALLEL_DOWNLOADS)
+        attachments = pool.map(self._download_attachment, self.attachment_urls)
+        filenames = map(self._filename_for_url, self.attachment_urls)
+        return zip(filenames, attachments)
+
     @XBlock.json_handler
     def get_response(self, data, suffix=""):  # pylint: disable=unused-argument
         """Get LLM feedback"""
         user_submission = str(data["user_input"])
+
+        attachments = []
+        for filename, contents in self._get_attachments():
+            attachments.append(f"""
+                <attachment>
+                    <filename>{saxutils.escape(filename)}</filename>
+                    <contents>{saxutils.escape(contents)}</contents>
+                </attachment>
+            """)
+        attachments = '\n'.join(attachments)
+
         system_msg = {
             "role": "system",
             "content": f"""
-               {self.evaluation_prompt}
+                {self.evaluation_prompt}
 
-               {self.question}.
+                {attachments}
 
-               Evaluation must be in Makrdown format.
-               """,
+                {self.question}.
+
+                Evaluation must be in Markdown format.
+            """,
         }
         messages = [system_msg]
         # add previous messages

--- a/ai_eval/static/css/chatbox.css
+++ b/ai_eval/static/css/chatbox.css
@@ -1,5 +1,3 @@
-/* CSS for ShortAnswerAIEvalXBlock */
-
 .shortanswer_image {
   float: left;
   margin-right: 4rem;
@@ -18,7 +16,7 @@
   cursor: pointer;
 }
 
-.chat-history {
+#chat-history {
   min-height: 250px;
   max-height: 400px;
   overflow-y: auto;
@@ -29,6 +27,7 @@
 .chat-message-container {
   display: flex;
 }
+
 .chat-message-container .chat-message {
   flex: 0 1 auto;
   max-width: 80%;
@@ -45,12 +44,13 @@
 }
 
 .ai-eval,
-.message-spinner {
+#message-spinner {
   text-align: left;
   color: white;
   margin-right: auto;
   background-color: #476480;
 }
+
 .ai-eval * {
   color: white !important;
 }
@@ -62,7 +62,7 @@
   padding: 10px;
 }
 
-.submit-row .user-input {
+.submit-row textarea {
   flex: 8;
   height: auto;
   border: 1px solid gray;
@@ -72,15 +72,16 @@
   resize: none;
 }
 
-#submit-button, #reset-button {
+.submit-row .chat-button {
   flex: 1;
   height: fit-content;
   text-align: center;
-  padding: 10px 0;
+  padding: 10px 5px;
   margin-left: auto;
   border-radius: 5px;
   border: none;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 #submit-button {
@@ -89,18 +90,20 @@
   margin-left: 10px;
 }
 
-#reset-button {
+#reset-button,
+#finish-button {
   border: 1px solid;
   color: #00262b;
   margin-right: 10px;
 }
 
-.submit-row .disabled-btn {
+.submit-row .disabled {
   opacity: 0.8;
   cursor: not-allowed !important;
 }
+
 /* spinner animation */
-.chat-message-container .message-spinner > div {
+.chat-message-container #message-spinner > div {
   width: 4px;
   height: 4px;
   margin-right: 2px;
@@ -112,12 +115,12 @@
   animation: chat-block-sk-bouncedelay 1.4s infinite ease-in-out both;
 }
 
-.chat-message-container.message-spinner .bounce1 {
+.chat-message-container #message-spinner .bounce1 {
   -webkit-animation-delay: -0.32s;
   animation-delay: -0.32s;
 }
 
-.chat-message-container .message-spinner .bounce2 {
+.chat-message-container #message-spinner .bounce2 {
   -webkit-animation-delay: -0.16s;
   animation-delay: -0.16s;
 }

--- a/ai_eval/static/html/jsoneditor-iframe.html
+++ b/ai_eval/static/html/jsoneditor-iframe.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/10.1.1/jsoneditor-minimalist.min.js"
+            integrity="sha512-VcA5u6MfLGhVp4tu1jGPXHQQSXPKbR6NQWWSnutvyz5a5cA0+G0GELJp3dJpE3+f1WT2ZMOgbhGf1r7NOIN1Rw=="
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"></script>
+</head>
+<body>
+</body>
+</html>

--- a/ai_eval/static/js/src/chatbox.js
+++ b/ai_eval/static/js/src/chatbox.js
@@ -1,0 +1,176 @@
+function ChatBox(runtime, element, data, handleInit, handleResponse,
+                 handleReset) {
+  "use strict";
+
+  loadMarkedInIframe(data.marked_html);
+
+  const handlerUrl = runtime.handlerUrl(element, "get_response");
+  const resetHandlerUrl = runtime.handlerUrl(element, "reset");
+
+  const $chatContainer = $("#chat-history", element);
+  const $spinner = $("#message-spinner", element);
+  const $spinnerContainer = $("#chat-spinner-container", element);
+  const $resetButton = $("#reset-button", element);
+  const $finishButton = $("#finish-button", element);
+  const $submitButton = $("#submit-button", element);
+  const $userInput = $("#user-input", element);
+
+  const enableControl = function($control, enable) {
+    $control.prop("disabled", !enable);
+    $control[enable ? "removeClass" : "addClass"]("disabled");
+  };
+
+  $userInput.on("input", function(event) {
+    const $input = $(this);
+    $input.height(0);
+    $input.height($input.prop("scrollHeight"));
+  });
+
+  const scrollToBottom = function() {
+    $chatContainer.scrollTop($chatContainer.prop("scrollHeight"));
+  };
+
+  const insertMessage = function(class_, content) {
+    const $message = $('<div class="chat-message">');
+    $message.addClass(class_);
+    $message.append(content);
+    const $messageContainer = $('<div class="chat-message-container">');
+    $messageContainer.append($message);
+    $messageContainer.insertBefore($spinnerContainer);
+    scrollToBottom();
+  };
+
+  const deleteLastMessage = function() {
+    $spinnerContainer.prev().remove();
+  };
+
+  const fns = {
+    enableReset: function(enable) {
+      const enabled = !$resetButton.prop("disabled");
+      enableControl($resetButton, enable);
+      return enabled;
+    },
+
+    enableInput: function(enable) {
+      const enabled = !$userInput.prop("disabled");
+      enableControl($userInput, enable);
+      enableControl($submitButton, enable);
+      enableControl($finishButton, enable);
+      return enabled;
+    },
+
+    insertUserMessage: function(content) {
+      if (content) {
+        insertMessage("user-answer", $(MarkdownToHTML(content)));
+      }
+    },
+
+    insertAIMessage: function(content) {
+      insertMessage("ai-eval", content);
+    },
+  };
+
+  const getResponse = function(inputData) {
+    const inputEnabled = fns.enableInput(false);
+    const resetEnabled = fns.enableReset(false);
+    if (inputData.user_input) {
+      fns.insertUserMessage(inputData.user_input);
+      $userInput.val("");
+      $userInput.trigger("input");
+    }
+    $spinner.show();
+    scrollToBottom();
+    $.ajax({
+      url: handlerUrl,
+      method: "POST",
+      data: JSON.stringify(inputData),
+      success: function(response) {
+        $spinner.hide();
+        fns.enableReset(true);
+        handleResponse.call(fns, response);
+      },
+      error: function() {
+        $spinner.hide();
+        fns.enableReset(resetEnabled);
+        fns.enableInput(inputEnabled);
+        if (inputData.user_input) {
+          deleteLastMessage();
+          $userInput.val(inputData.user_input);
+          $userInput.trigger("input");
+        }
+        alert(gettext("An error has occurred."));
+      },
+    });
+  };
+
+  const handleUserInput = function($input) {
+    if ($input.prop("disabled")) {
+      return;
+    }
+    if (!$input.val()) {
+      return;
+    }
+    getResponse({ user_input: $input.val() });
+  };
+
+  $userInput.keypress(function(event) {
+    if (event.keyCode == 13 && !event.shiftKey) {
+      event.preventDefault();
+      handleUserInput($(this));
+      return false;
+    }
+  });
+
+  $submitButton.click(function() {
+    if ($(this).prop("disabled")) {
+      return;
+    }
+    handleUserInput($userInput);
+  });
+
+  $finishButton.click(function() {
+    if ($(this).prop("disabled")) {
+      return;
+    }
+    getResponse({ force_finish: true });
+  });
+
+  $resetButton.click(function() {
+    if ($(this).prop("disabled")) {
+      return;
+    }
+    const inputEnabled = fns.enableInput(false);
+    const resetEnabled = fns.enableReset(false);
+    $spinner.show();
+    scrollToBottom();
+    $.ajax({
+      url: resetHandlerUrl,
+      method: "POST",
+      data: JSON.stringify({}),
+      success: function() {
+        $spinner.hide();
+        $spinnerContainer.prevAll('.chat-message-container').remove();
+        fns.enableInput(true);
+        handleReset.call(fns);
+      },
+      error: function() {
+        $spinner.hide();
+        fns.enableReset(resetEnabled);
+        fns.enableInput(inputEnabled);
+        alert(gettext("An error has occurred."));
+      },
+    });
+  });
+
+  var initDone = false;
+
+  const init = function() {
+    if (initDone) {
+      return;
+    }
+    initDone = true;
+    handleInit.call(fns);
+  };
+
+  runFuncAfterLoading(init);
+}

--- a/ai_eval/static/js/src/multiagent.js
+++ b/ai_eval/static/js/src/multiagent.js
@@ -1,0 +1,81 @@
+/* Javascript for MultiAgentAIEvalXBlock. */
+function MultiAgentAIEvalXBlock(runtime, element, data) {
+  "use strict";
+
+  const formatAIMessage = function(content, is_evaluator, agent,
+                                   character_data) {
+    var name;
+    if (is_evaluator) {
+      name = gettext("Evaluator");
+    } else {
+      if (character_data && character_data.name) {
+        name = character_data.name;
+      }
+      var role_text;
+      if (agent && agent !== data.main_character_agent) {
+        role_text = `<i>${agent}</i>`;
+      }
+      if (character_data && character_data.role) {
+        if (role_text) {
+          role_text = `${role_text}, ${character_data.role}`;
+        } else {
+          role_text = character_data.role;
+        }
+      }
+      if (role_text) {
+        if (name) {
+          name = `${name} (${role_text})`;
+        } else {
+          name = role_text;
+        }
+      }
+    }
+    if (name) {
+      name = `${name}:`;
+    } else {
+      name = "";
+    }
+
+    return $(`
+      <b>${name}</b>
+      ${MarkdownToHTML(content)}
+    `);
+  };
+
+  const formatInitialMessage = function() {
+    return formatAIMessage(data.initial_message, false,
+                           data.main_character_agent,
+                           data.main_character_data);
+  };
+
+  const handleInit = function() {
+    this.insertAIMessage(formatInitialMessage());
+    for (var i = 0; i < data.messages.length; i++) {
+      var message = data.messages[i];
+      if (message.role === "user") {
+        this.insertUserMessage(message.content);
+      } else {
+        this.insertAIMessage(formatAIMessage(message.content,
+                                             message.extra.is_evaluator,
+                                             message.extra.role,
+                                             message.extra.character_data));
+      }
+    }
+    this.enableReset(data.messages.length > 0 || data.finished);
+    this.enableInput(!data.finished);
+  };
+
+  const handleResponse = function(response) {
+    this.insertAIMessage(formatAIMessage(response.message,
+                                         response.is_evaluator,
+                                         response.role,
+                                         response.character_data));
+    this.enableInput(!response.finished);
+  };
+
+  const handleReset = function() {
+    this.insertAIMessage(formatInitialMessage());
+  };
+
+  ChatBox(runtime, element, data, handleInit, handleResponse, handleReset);
+}

--- a/ai_eval/static/js/src/multiagent_edit.js
+++ b/ai_eval/static/js/src/multiagent_edit.js
@@ -1,0 +1,100 @@
+/* Javascript for MultiAgentAIEvalXBlock. */
+function MultiAgentAIEvalXBlock(runtime, element, data) {
+    "use strict";
+
+    StudioEditableXBlockMixin(runtime, element);
+
+    var $fields = $('#xb-field-edit-scenario_data, #xb-field-edit-character_data');
+
+    var addFileInput = function() {
+        var $wrapper = $('<div/>');
+        $wrapper.css('margin-left', 'calc(25% + 15px)');
+        $wrapper.css('margin-top', '5px');
+        var $fileInput = $('<input type="file"/>');
+        $fileInput.css('width', 'calc(45% - 10px)');
+        $wrapper.append($fileInput);
+        var $loadButton = $('<button class="action" type="button"/>');
+        $loadButton.append(gettext("Load"));
+        $loadButton.click(loadFile);
+        $loadButton.css('margin-left', '10px');
+        $wrapper.append($loadButton);
+
+        $(this).closest('.wrapper-comp-setting').append($wrapper);
+    }
+
+    var loadFile = function() {
+        var $button = $(this);
+        var $fileInput = $button.prev('input[type="file"]');
+        var $field = $button.closest('.wrapper-comp-setting').children('textarea');
+        var file = $fileInput[0].files[0];
+        if (file !== undefined) {
+            var reader = new FileReader();
+            reader.onload = function(e) {
+                $field.val(JSON.stringify(JSON.parse(e.target.result), null, 2));
+                $field.trigger("change");
+            }
+            reader.readAsText(file);
+        }
+    }
+
+    $fields.each(addFileInput);
+
+    var addJSONEditor = function() {
+        var $field = $(this);
+        var $container = $('<div/>');
+        $container.css('display', 'inline-block');
+        $container.css('vertical-align', 'top');
+        $container.css('width', '45%');
+        $field.css('display', 'none');
+        $container.insertAfter($field);
+        var options = {
+            enableSort: false,
+            enableTransform: false,
+            modes: ['tree', 'text'],
+            navigationBar: false,
+            search: false,
+            onChangeText: function(value) {
+                $field.val(value);
+                $field.trigger("change");
+            },
+        };
+        var editor = new JSONEditor($container[0], options);
+        editor.setText($field.val());
+
+        var $wrapper = $field.closest('li');
+        var $resetButton = $wrapper.find('button.setting-clear');
+        $resetButton.click(function() {
+            editor.setText($field.val());
+        });
+
+        $field.on('change', function() {
+            var value = $field.val();
+            if (value !== editor.getText()) {
+                editor.setText(value);
+            }
+        });
+    }
+
+    if (window.JSONEditor !== undefined) {
+        $fields.each(addJSONEditor);
+    } else {
+        $('head').append($(
+            '<link ' +
+            'rel="stylesheet" ' +
+            'href="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/10.1.1/' +
+            'jsoneditor.min.css" ' +
+            'integrity="sha512-8G+Vb2+10BSrSo+wupdzJIylDLpGtEYniQhp0rsbTigPG' +
+            '7Onn2S08Ai/KEGlxN2Ncx9fGqVHtRehMuOjPb9f8g==" ' +
+            'crossorigin="anonymous" ' +
+            'referrerpolicy="no-referrer" />'
+        ));
+        var $jsoneditorIframe = $('<iframe>');
+        $jsoneditorIframe.css('display', 'none');
+        $jsoneditorIframe.on('load', function() {
+            window.JSONEditor = $(this)[0].contentWindow.JSONEditor;
+            $fields.each(addJSONEditor);
+        });
+        $jsoneditorIframe.attr('srcdoc', data.jsoneditor_html);
+        $(document.body).append($jsoneditorIframe);
+    }
+}

--- a/ai_eval/static/js/src/shortanswer.js
+++ b/ai_eval/static/js/src/shortanswer.js
@@ -1,129 +1,27 @@
 /* Javascript for ShortAnswerAIEvalXBlock. */
 function ShortAnswerAIEvalXBlock(runtime, element, data) {
-  const handlerUrl = runtime.handlerUrl(element, "get_response");
-  const resetHandlerURL = runtime.handlerUrl(element, "reset");
+  "use strict";
 
-  loadMarkedInIframe(data.marked_html);
+  const formatAIMessage = function(msg) {
+    return $(MarkdownToHTML(msg));
+  };
 
-  $(function () {
-    const spinner = $(".message-spinner", element);
-    const spinnnerContainer = $("#chat-spinner-container", element);
-    const resetButton = $("#reset-button", element);
-    const submitButton = $("#submit-button", element);
-    const userInput = $(".user-input", element);
-    const userInputElem = userInput[0];
-    let initDone = false;
-
-    runFuncAfterLoading(init);
-
-    function getResponse() {
-      if (!userInput.val().length) return;
-
-      disableInput();
-      spinner.show();
-      insertUserMessage(userInput.val());
-      $.ajax({
-        url: handlerUrl,
-        method: "POST",
-        data: JSON.stringify({ user_input: userInput.val() }),
-        success: function (response) {
-          spinner.hide();
-          insertAIMessage(response.response);
-          userInput.val("");
-          if ($(".user-answer", element).length >= data.max_responses) {
-            disableInput();
-          } else {
-            enableInput();
-          }
-        },
-        error: function (jqXHR, textStatus, errorThrown) {
-          spinner.hide();
-          alert(errorThrown);
-
-          deleteLastMessage();
-          enableInput();
-        },
-      });
+  const handleInit = function() {
+    $("#question-text", element).html(MarkdownToHTML(data.question));
+    for (var i = 0; i < data.messages.USER.length; i++) {
+      this.insertUserMessage(data.messages.USER[i]);
+      this.insertAIMessage(formatAIMessage(data.messages.LLM[i]));
     }
+    this.enableInput(data.messages.USER.length < data.max_responses);
+    this.enableReset(data.messages.USER.length > 0);
+  };
 
-    submitButton.click(getResponse);
+  const handleResponse = function(response) {
+    this.insertAIMessage(formatAIMessage(response.response));
+    this.enableInput($(".user-answer", element).length < data.max_responses);
+  };
 
-    resetButton.click(() => {
-      if (!resetButton.hasClass("disabled-btn")) {
-        $.ajax({
-          url: resetHandlerURL,
-          method: "POST",
-          data: JSON.stringify({}),
-          success: function (data) {
-            spinnnerContainer.prevAll('.chat-message-container').remove();
-            resetButton.addClass("disabled-btn");
-            enableInput();
-          },
-          error: function(xhr, status, error) {
-            console.error('Error:', error);
-            alert("A problem occured during reset.");
-          }
-        });
-      }
-    });
+  const handleReset = function() {};
 
-    function disableInput() {
-      userInput.prop("disabled", true);
-      userInput.removeAttr("placeholder");
-      submitButton.prop("disabled", true);
-      submitButton.addClass("disabled-btn");
-    }
-
-    function enableInput() {
-      userInput.prop("disabled", false);
-      submitButton.prop("disabled", false);
-      submitButton.removeClass("disabled-btn");
-    }
-
-    function adjustTextareaHeight(element) {
-      element.style.height = "";
-      element.style.height = element.scrollHeight + "px";
-    }
-    userInputElem.addEventListener("input", (event) => {
-      adjustTextareaHeight(userInputElem);
-    });
-
-    function init() {
-      if (initDone) return;
-      initDone = true;
-      $("#question-text", element).html(MarkdownToHTML(data.question));
-      for (let i = 0; i < data.messages.USER.length; i++) {
-        insertUserMessage(data.messages.USER[i]);
-        insertAIMessage(data.messages.LLM[i]);
-        resetButton.removeClass("disabled-btn");
-      }
-      if (
-        data.messages.USER.length &&
-        data.messages.USER.length >= data.max_responses
-      ) {
-        disableInput();
-      }
-    }
-
-    function insertUserMessage(msg) {
-      if (msg?.length) {
-        $(` <div class="chat-message-container">
-                <div class="chat-message user-answer">${MarkdownToHTML(msg)}</div>
-      </div>`).insertBefore(spinnnerContainer);
-        resetButton.removeClass("disabled-btn");
-      }
-    }
-
-    function insertAIMessage(msg) {
-      if (msg?.length) {
-        $(` <div class="chat-message-container">
-                <div class="chat-message ai-eval">${MarkdownToHTML(msg)}</div>
-      </div>`).insertBefore(spinnnerContainer);
-        resetButton.removeClass("disabled-btn");
-      }
-    }
-    function deleteLastMessage() {
-      spinnnerContainer.prev().remove();
-    }
-  });
+  ChatBox(runtime, element, data, handleInit, handleResponse, handleReset);
 }

--- a/ai_eval/templates/chatbox.html
+++ b/ai_eval/templates/chatbox.html
@@ -7,14 +7,14 @@
 <div class="shortanswer_block">
     <div>
         <div id="question-text">
-            Loading ..
+            {{ question_text | safe }}
         </div>
     </div>
 
     <div>
-        <div class="chat-history">
+        <div id="chat-history">
             <div class="chat-message-container" id="chat-spinner-container">
-                <div class="chat-message message-spinner" style="display: none;">
+                <div class="chat-message" id="message-spinner" style="display: none;">
                     <div class="bounce1">
                     </div>
                     <div class="bounce2">
@@ -26,10 +26,13 @@
         </div>
         <div class="submit-row">
             {% if self.allow_reset %}
-                <span id="reset-button" class="disabled-btn">Reset chat</span>
+                <span class="chat-button" id="reset-button">Reset chat</span>
             {% endif %}
-            <textarea class="user-input" rows="1" placeholder="Type your answer here" maxlength="1000"></textarea>
-            <span id="submit-button">Submit <i class="fa fa-paper-plane"></i></span>
+            {% if has_finish_button %}
+                <span class="chat-button" id="finish-button">Submit for evaluation</span>
+            {% endif %}
+            <textarea id="user-input" rows="1" placeholder="Type your answer here" maxlength="1000"></textarea>
+            <span class="chat-button" id="submit-button">Submit <i class="fa fa-paper-plane"></i></span>
         </div>
     </div>
 </div>

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -10,7 +10,11 @@ from xblock.exceptions import JsonHandlerError
 from xblock.field_data import DictFieldData
 from xblock.test.toy_runtime import ToyRuntime
 
-from ai_eval import CodingAIEvalXBlock, ShortAnswerAIEvalXBlock
+from ai_eval import (
+    CodingAIEvalXBlock,
+    MultiAgentAIEvalXBlock,
+    ShortAnswerAIEvalXBlock,
+)
 from ai_eval.base import AIEvalXBlock
 from ai_eval.llm import SupportedModels
 
@@ -120,6 +124,58 @@ def test_character_image(shortanswer_block_data):
     block = ShortAnswerAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
     frag = block.student_view()
     assert '<img src="/static/image.jpg" />' in frag.content
+
+
+def test_multiagent_block_finished():
+    """Test the MultiAgentAIEvalXBlock for not allowing input after finished."""
+    data = {
+        "finished": True
+    }
+    block = MultiAgentAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
+    with pytest.raises(JsonHandlerError):
+        block.get_response.__wrapped__(block, data={})
+
+
+def test_multiagent_block_force_finish():
+    """Test force finish for the MultiAgentAIEvalXBlock."""
+    data = {}
+    block = MultiAgentAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
+    block._get_evaluator_response = Mock(return_value="evaluator response")
+    resp = block.get_response.__wrapped__(block, data={"force_finish": True})
+    assert resp["message"] == "evaluator response"
+    assert resp["finished"]
+    assert resp["is_evaluator"]
+
+
+def test_multiagent_block_response():
+    """Test regular response for the MultiAgentAIEvalXBlock."""
+    data = {}
+    block = MultiAgentAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
+    block._get_next_agent = Mock(return_value="Character")
+    block._get_agent_response = Mock(return_value="agent response")
+    block._get_character_data = Mock(return_value={"role": "role"})
+    resp = block.get_response.__wrapped__(block, data={"user_input": "hi"})
+    block._get_next_agent.assert_called_once_with("hi")
+    block._get_agent_response.assert_called_once_with("Character", "hi")
+    assert resp["message"] == "agent response"
+    assert not resp["finished"]
+    assert not resp["is_evaluator"]
+    assert resp["role"] == "Character"
+    assert resp["character_data"]["role"] == "role"
+
+
+def test_multiagent_block_evaluator_response():
+    """Test evaluator response for the MultiAgentAIEvalXBlock."""
+    data = {}
+    block = MultiAgentAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
+    block._get_next_agent = Mock(return_value="FINISH")
+    block._get_evaluator_response = Mock(return_value="evaluator response")
+    resp = block.get_response.__wrapped__(block, data={"user_input": "end"})
+    block._get_next_agent.assert_called_once_with("end")
+    block._get_evaluator_response.assert_called_once_with("end")
+    assert resp["message"] == "evaluator response"
+    assert resp["finished"]
+    assert resp["is_evaluator"]
 
 
 @pytest.mark.parametrize(

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -126,6 +126,25 @@ def test_character_image(shortanswer_block_data):
     assert '<img src="/static/image.jpg" />' in frag.content
 
 
+def test_shortanswer_attachments(shortanswer_block_data):
+    """Test attachments for ShortAnswerAIEvalXBlock."""
+    data = {
+        **shortanswer_block_data,
+        "attachment_urls": [
+            "http://example.com/1.txt",
+            "http://example.com/2.txt",
+        ],
+    }
+    block = ShortAnswerAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
+    block._download_attachment = Mock(return_value="file contents <&>")
+    block.get_llm_response = Mock(return_value=".")
+    block.get_response.__wrapped__(block, data={"user_input": "."})
+    messages = block.get_llm_response.call_args.args[0]
+    prompt = messages[0]["content"]
+    assert "<filename>1.txt</filename>" in prompt
+    assert "<contents>file contents &lt;&amp;&gt;</contents>" in prompt
+
+
 def test_multiagent_block_finished():
     """Test the MultiAgentAIEvalXBlock for not allowing input after finished."""
     data = {

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,3 +4,4 @@
 django-statici18n
 XBlock[django]
 litellm
+Jinja2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.5.0
     # via aiohttp
 aiohttp==3.11.13
     # via litellm
@@ -25,9 +25,9 @@ attrs==25.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.37.1
+boto3==1.37.9
     # via fs-s3fs
-botocore==1.37.1
+botocore==1.37.9
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ click==8.1.8
     # via litellm
 distro==1.9.0
     # via openai
-django==4.2.19
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   django-appconf
@@ -65,7 +65,7 @@ fs==2.4.16
     #   xblock
 fs-s3fs==1.1.1
     # via openedx-django-pyfs
-fsspec==2025.2.0
+fsspec==2025.3.0
     # via huggingface-hub
 h11==0.14.0
     # via httpcore
@@ -75,7 +75,7 @@ httpx==0.28.1
     # via
     #   litellm
     #   openai
-huggingface-hub==0.29.1
+huggingface-hub==0.29.2
     # via tokenizers
 idna==3.10
     # via
@@ -85,8 +85,10 @@ idna==3.10
     #   yarl
 importlib-metadata==8.6.1
     # via litellm
-jinja2==3.1.5
-    # via litellm
+jinja2==3.1.6
+    # via
+    #   -r requirements/base.in
+    #   litellm
 jiter==0.8.2
     # via openai
 jmespath==1.0.1
@@ -99,7 +101,7 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 lazy==1.6
     # via xblock
-litellm==1.61.17
+litellm==1.63.3
     # via -r requirements/base.in
 lxml==5.3.1
     # via xblock
@@ -114,7 +116,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-openai==1.64.0
+openai==1.65.5
     # via litellm
 openedx-django-pyfs==3.7.0
     # via xblock
@@ -156,7 +158,7 @@ rpds-py==0.23.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via boto3
 simplejson==3.20.1
     # via xblock
@@ -196,10 +198,8 @@ web-fragments==2.2.0
     # via xblock
 webob==1.8.9
     # via xblock
-xblock[django]==4.0.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+xblock[django]==5.1.2
+    # via -r requirements/base.in
 yarl==1.18.3
     # via aiohttp
 zipp==3.21.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -28,7 +28,7 @@ pluggy==1.5.0
     # via tox
 pyproject-api==1.9.0
     # via tox
-tox==4.24.1
+tox==4.24.2
     # via -r requirements/ci.in
-virtualenv==20.29.2
+virtualenv==20.29.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.5.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
@@ -37,7 +37,7 @@ asgiref==3.8.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -52,11 +52,11 @@ binaryornot==0.4.4
     # via
     #   -r requirements/quality.txt
     #   cookiecutter
-boto3==1.37.1
+boto3==1.37.9
     # via
     #   -r requirements/quality.txt
     #   fs-s3fs
-botocore==1.37.1
+botocore==1.37.9
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -129,7 +129,7 @@ distro==1.9.0
     # via
     #   -r requirements/quality.txt
     #   openai
-django==4.2.19
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -171,7 +171,7 @@ fs-s3fs==1.1.1
     #   -r requirements/quality.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.2.0
+fsspec==2025.3.0
     # via
     #   -r requirements/quality.txt
     #   huggingface-hub
@@ -188,7 +188,7 @@ httpx==0.28.1
     #   -r requirements/quality.txt
     #   litellm
     #   openai
-huggingface-hub==0.29.1
+huggingface-hub==0.29.2
     # via
     #   -r requirements/quality.txt
     #   tokenizers
@@ -207,11 +207,11 @@ iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==6.0.0
+isort==6.0.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -238,7 +238,7 @@ lazy==1.6
     # via
     #   -r requirements/quality.txt
     #   xblock
-litellm==1.61.17
+litellm==1.63.3
     # via -r requirements/quality.txt
 lxml[html-clean]==5.3.1
     # via
@@ -273,14 +273,14 @@ mdurl==0.1.2
     # via
     #   -r requirements/quality.txt
     #   markdown-it-py
-mock==5.1.0
+mock==5.2.0
     # via -r requirements/quality.txt
 multidict==6.1.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-openai==1.64.0
+openai==1.65.5
     # via
     #   -r requirements/quality.txt
     #   litellm
@@ -345,7 +345,7 @@ pygments==2.19.1
     # via
     #   -r requirements/quality.txt
     #   rich
-pylint==3.3.4
+pylint==3.3.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -378,7 +378,7 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -439,7 +439,7 @@ rpds-py==0.23.1
     #   -r requirements/quality.txt
     #   jsonschema
     #   referencing
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -484,7 +484,7 @@ tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.24.1
+tox==4.24.2
     # via -r requirements/ci.txt
 tqdm==4.67.1
     # via
@@ -510,7 +510,7 @@ urllib3==2.2.3
     #   -r requirements/quality.txt
     #   botocore
     #   requests
-virtualenv==20.29.2
+virtualenv==20.29.3
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -528,9 +528,8 @@ wheel==0.45.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-xblock[django]==4.0.1
+xblock[django]==5.1.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   xblock-sdk
 xblock-sdk==0.12.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.8.1
+setuptools==76.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.5.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -37,7 +37,7 @@ asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   pylint
     #   pylint-celery
@@ -51,11 +51,11 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-boto3==1.37.1
+boto3==1.37.9
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.37.1
+botocore==1.37.9
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -102,7 +102,7 @@ distro==1.9.0
     # via
     #   -r requirements/test.txt
     #   openai
-django==4.2.19
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -141,7 +141,7 @@ fs-s3fs==1.1.1
     #   -r requirements/test.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.2.0
+fsspec==2025.3.0
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
@@ -158,7 +158,7 @@ httpx==0.28.1
     #   -r requirements/test.txt
     #   litellm
     #   openai
-huggingface-hub==0.29.1
+huggingface-hub==0.29.2
     # via
     #   -r requirements/test.txt
     #   tokenizers
@@ -177,9 +177,9 @@ iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==6.0.0
+isort==6.0.1
     # via pylint
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -206,7 +206,7 @@ lazy==1.6
     # via
     #   -r requirements/test.txt
     #   xblock
-litellm==1.61.17
+litellm==1.63.3
     # via -r requirements/test.txt
 lxml[html-clean]==5.3.1
     # via
@@ -239,14 +239,14 @@ mdurl==0.1.2
     # via
     #   -r requirements/test.txt
     #   markdown-it-py
-mock==5.1.0
+mock==5.2.0
     # via -r requirements/test.txt
 multidict==6.1.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-openai==1.64.0
+openai==1.65.5
     # via
     #   -r requirements/test.txt
     #   litellm
@@ -295,7 +295,7 @@ pygments==2.19.1
     # via
     #   -r requirements/test.txt
     #   rich
-pylint==3.3.4
+pylint==3.3.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -313,7 +313,7 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -374,7 +374,7 @@ rpds-py==0.23.1
     #   -r requirements/test.txt
     #   jsonschema
     #   referencing
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -449,9 +449,8 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-xblock[django]==4.0.1
+xblock[django]==5.1.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   xblock-sdk
 xblock-sdk==0.12.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.5.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -43,11 +43,11 @@ attrs==25.1.0
     #   referencing
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.37.1
+boto3==1.37.9
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.37.1
+botocore==1.37.9
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -115,7 +115,7 @@ fs-s3fs==1.1.1
     #   -r requirements/base.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.2.0
+fsspec==2025.3.0
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
@@ -132,7 +132,7 @@ httpx==0.28.1
     #   -r requirements/base.txt
     #   litellm
     #   openai
-huggingface-hub==0.29.1
+huggingface-hub==0.29.2
     # via
     #   -r requirements/base.txt
     #   tokenizers
@@ -149,7 +149,7 @@ importlib-metadata==8.6.1
     #   litellm
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/base.txt
     #   cookiecutter
@@ -175,7 +175,7 @@ lazy==1.6
     # via
     #   -r requirements/base.txt
     #   xblock
-litellm==1.61.17
+litellm==1.63.3
     # via -r requirements/base.txt
 lxml[html-clean]==5.3.1
     # via
@@ -200,14 +200,14 @@ markupsafe==3.0.2
     #   xblock
 mdurl==0.1.2
     # via markdown-it-py
-mock==5.1.0
+mock==5.2.0
     # via -r requirements/test.in
 multidict==6.1.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-openai==1.64.0
+openai==1.65.5
     # via
     #   -r requirements/base.txt
     #   litellm
@@ -245,7 +245,7 @@ pygments==2.19.1
     # via rich
 pypng==0.20220715.0
     # via xblock-sdk
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   pytest-cov
     #   pytest-django
@@ -299,7 +299,7 @@ rpds-py==0.23.1
     #   -r requirements/base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -365,9 +365,8 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-xblock[django]==4.0.1
+xblock[django]==5.1.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   xblock-sdk
 xblock-sdk==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "xblock.v1": [
             "shortanswer_ai_eval = ai_eval:ShortAnswerAIEvalXBlock",
             "coding_ai_eval = ai_eval:CodingAIEvalXBlock",
+            "multiagent_ai_eval = ai_eval:MultiAgentAIEvalXBlock",
         ]
     },
     package_data=package_data("ai_eval", ["static", "public", "templates"]),


### PR DESCRIPTION
## Description

Allows attachments to be loaded from an URL for the short answer AI XBlock.

## Testing instructions

1. Add "shortanswer_ai_eval" and configure required settings.
2. Set "Evaluation prompt" to "Provide information on the attachments", in order to be able to ask about the attachments
3. Set `["http://example.com"]` as attachment URLs.
4. Use the XBlock, ask the LLM about the attachment contents.

![image](https://github.com/user-attachments/assets/e24a695f-b9ea-48db-84ac-91ca1b053496)

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-9554