### PR TITLE
Pooja/bb 9550 use custom service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         python-version: [3.11, 3.12]
         toxenv: [django42, quality]
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -67,6 +67,32 @@ API URLs are only required and used with the LLAMA model (`ollama/llama2`). Othe
 For better security, we recommend using site configuration or Django settings instead of configuring API keys at the 
 XBlock level. This prevents API keys from being exposed in course exports.
 
+### Custom LLM Service (advanced)
+
+The XBlocks can optionally route all LLM interactions through a custom LLM service instead of the default provider.
+To enable a custom service, configure the following **Site Configuration** keys under the `ai_eval` namespace:
+
+```json
+{
+  "ai_eval": {
+    "USE_CUSTOM_LLM_SERVICE": true,
+    "CUSTOM_LLM_MODELS_URL": "https://your-custom-service/models",
+    "CUSTOM_LLM_COMPLETIONS_URL": "https://your-custom-service/completions",
+    "CUSTOM_LLM_TOKEN_URL": "https://your-custom-service/oauth/token"
+  }
+}
+```
+
+Additionally, set your client credentials in Django settings (e.g. via Tutor config):
+
+```python
+CUSTOM_LLM_CLIENT_ID = "your-client-id"
+CUSTOM_LLM_CLIENT_SECRET = "your-client-secret"
+```
+
+Your custom service must implement the expected OAuth2 client‑credentials flow and provide JSON endpoints
+for listing models, obtaining completions, and fetching tokens as used by `CustomLLMService`.
+
 ## Dependencies
 - [Judge0 API](https://judge0.com/)
 - [Monaco editor](https://github.com/microsoft/monaco-editor)

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -126,7 +126,9 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             llm_service = get_llm_service()
             available_models = llm_service.get_available_models()
             choices = [{"display_name": m, "value": m} for m in available_models]
-            self.fields["model"].values = choices
+            model_field = self.fields["model"]
+            model_field.values.clear()
+            model_field.values.extend(choices)
 
             # Set default if no model is selected
             if available_models and not getattr(data, "model", None):
@@ -135,7 +137,9 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             # Fallback to default models if service fails
             fallback_models = SupportedModels.list()
             choices = [{"display_name": m, "value": m} for m in fallback_models]
-            self.fields["model"].values = choices
+            model_field = self.fields["model"]
+            model_field.values.clear()
+            model_field.values.extend(choices)
             if not getattr(data, "model", None):
                 data.model = fallback_models[0]
             available_models = fallback_models

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -11,7 +11,8 @@ from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xblock.validation import ValidationMessage
 
 from .compat import get_site_configuration_value
-from .llm import SupportedModels, get_llm_response
+from .llm import SupportedModels, get_llm_response, get_llm_service
+from .llm_services import DefaultLLMService
 
 
 @XBlock.wants("settings")
@@ -32,7 +33,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
     model_api_url = String(
         display_name=_("Set your API URL"),
         help=_(
-            "Fill this only for LLama. This required with models that don't have an official provider."
+            "Fill this only for LLama. This is required with models that don't have an official provider."
             " Example URL: https://model-provider-example/llama3_70b"
         ),
         default=None,
@@ -41,11 +42,8 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
     model = String(
         display_name=_("AI model"),
         help=_("Select the AI language model to use."),
-        values=[
-            {"display_name": model, "value": model} for model in SupportedModels.list()
-        ],
-        Scope=Scope.settings,
-        default=SupportedModels.GPT4O.value,
+        values=[],
+        scope=Scope.settings,
     )
 
     editable_fields = (
@@ -88,7 +86,14 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         """
         obj = obj or self
         field_name = f"model_{config_parameter}"
-        config_key = f"{SupportedModels(obj.model).name}_{config_parameter.upper()}"
+
+        # For custom models, use the model name directly; for supported models, use the enum name
+        try:
+            model_name = SupportedModels(obj.model).name
+        except ValueError:
+            model_name = obj.model.replace("/", "_").replace("-", "_").upper()
+
+        config_key = f"{model_name}_{config_parameter.upper()}"
 
         # XBlock field
         if value := getattr(obj, field_name, None):
@@ -114,44 +119,62 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
 
     def validate_field_data(self, validation, data):
         """
-        Validate fields.
+        Validate fields and populate model choices dynamically.
         """
+        # Populate model choices dynamically before validation
+        try:
+            llm_service = get_llm_service()
+            available_models = llm_service.get_available_models()
+            choices = [{"display_name": m, "value": m} for m in available_models]
+            self.fields["model"].values = choices
 
-        if not data.model or data.model not in SupportedModels.list():
+            # Set default if no model is selected
+            if available_models and not getattr(data, "model", None):
+                data.model = available_models[0]
+        except Exception:
+            # Fallback to default models if service fails
+            fallback_models = SupportedModels.list()
+            choices = [{"display_name": m, "value": m} for m in fallback_models]
+            self.fields["model"].values = choices
+            if not getattr(data, "model", None):
+                data.model = fallback_models[0]
+            available_models = fallback_models
+
+        if not data.model or data.model not in available_models:
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR,
-                    _(  # pylint: disable=translation-of-non-string
-                        f"Model field is mandatory and must be one of {', '.join(SupportedModels.list())}"
-                    ),
+                    _(f"Model field is mandatory and must be one of {', '.join(available_models)}")
                 )
             )
 
-        if not self.get_model_api_key(data):
-            validation.add(
-                ValidationMessage(
-                    ValidationMessage.ERROR, _("Model API key is mandatory, if not set globally by your administrator.")
+        # Only run these checks for the default service
+        if isinstance(llm_service, DefaultLLMService):
+            if not self.get_model_api_key(data):
+                validation.add(
+                    ValidationMessage(
+                        ValidationMessage.ERROR, _("Model API key is mandatory, if not set globally by your administrator.")
+                    )
                 )
-            )
 
-        if data.model == SupportedModels.LLAMA.value and not self.get_model_api_url(data):
-            validation.add(
-                ValidationMessage(
-                    ValidationMessage.ERROR,
-                    _(
-                        "API URL field is mandatory when using ollama/llama2, "
-                        "if not set globally by your administrator."
-                    ),
+            if data.model == SupportedModels.LLAMA.value and not self.get_model_api_url(data):
+                validation.add(
+                    ValidationMessage(
+                        ValidationMessage.ERROR,
+                        _(
+                            "API URL field is mandatory when using ollama/llama2, "
+                            "if not set globally by your administrator."
+                        ),
+                    )
                 )
-            )
 
-        if data.model != SupportedModels.LLAMA.value and data.model_api_url:
-            validation.add(
-                ValidationMessage(
-                    ValidationMessage.ERROR,
-                    _("API URL field can be set only when using ollama/llama2."),
+            if data.model != SupportedModels.LLAMA.value and data.model_api_url:
+                validation.add(
+                    ValidationMessage(
+                        ValidationMessage.ERROR,
+                        _("API URL field can be set only when using ollama/llama2."),
+                    )
                 )
-            )
 
     def get_llm_response(self, messages):
         return get_llm_response(self.model, self.get_model_api_key(), messages,

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -14,6 +14,10 @@ from .compat import get_site_configuration_value
 from .llm import SupportedModels, get_llm_response, get_llm_service
 from .llm_services import DefaultLLMService
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @XBlock.wants("settings")
 class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
@@ -133,8 +137,11 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             # Set default if no model is selected
             if available_models and not getattr(data, "model", None):
                 data.model = available_models[0]
-        except Exception:
-            # Fallback to default models if service fails
+        except Exception as e:
+            logger.error(
+                f"Failed to populate model choices dynamically; falling back to default models. Error: {e}",
+                exc_info=True,
+            )
             fallback_models = SupportedModels.list()
             choices = [{"display_name": m, "value": m} for m in fallback_models]
             model_field = self.fields["model"]

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -137,6 +137,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             # Set default if no model is selected
             if available_models and not getattr(data, "model", None):
                 data.model = available_models[0]
+                self.model = available_models[0]
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error(
                 f"Failed to populate model choices dynamically; falling back to default models. Error: {e}",
@@ -149,6 +150,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             model_field.values.extend(choices)
             if not getattr(data, "model", None):
                 data.model = fallback_models[0]
+                self.model = fallback_models[0]
             available_models = fallback_models
 
         if not data.model or data.model not in available_models:

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -42,7 +42,9 @@ def _get_model_choices(block):
         )
         available_models = SupportedModels.list()
 
-    return [{"display_name": m, "value": m} for m in available_models]
+    PLACEHOLDER = {"display_name": "— Select a model —", "value": ""}
+
+    return [PLACEHOLDER] + [{"display_name": m, "value": m} for m in available_models]
 
 
 @XBlock.wants("settings")

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -19,6 +19,32 @@ from .llm import get_llm_response, get_llm_service
 logger = logging.getLogger(__name__)
 
 
+def _get_model_choices(block):
+    """
+    Return the dropdown entries for the `model` field.
+    If the remote service fails, fall back to SupportedModels.list().
+    """
+    available_models = []
+
+    try:
+        llm_service = get_llm_service()
+        available_models = llm_service.get_available_models()
+
+        # Ensure we have models, fallback if empty
+        if not available_models:
+            logger.warning("Custom service returned empty models list, using defaults")
+            available_models = SupportedModels.list()
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error(
+            f"Failed to populate model choices dynamically; falling back to default models. Error: {e}",
+            exc_info=True,
+        )
+        available_models = SupportedModels.list()
+
+    return [{"display_name": m, "value": m} for m in available_models]
+
+
 @XBlock.wants("settings")
 class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
     """
@@ -46,8 +72,9 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
     model = String(
         display_name=_("AI model"),
         help=_("Select the AI language model to use."),
-        values=[],
         scope=Scope.settings,
+        default="",
+        values_provider=_get_model_choices,
     )
 
     editable_fields = (
@@ -125,45 +152,30 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Validate fields and populate model choices dynamically.
         """
-        # Populate model choices dynamically before validation
-        try:
-            llm_service = get_llm_service()
-            available_models = llm_service.get_available_models()
-            choices = [{"display_name": m, "value": m} for m in available_models]
-            model_field = self.fields["model"]
-            model_field.values.clear()
-            model_field.values.extend(choices)
-
-            # Set default if no model is selected
-            if available_models and not getattr(data, "model", None):
-                data.model = available_models[0]
-                self.model = available_models[0]
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(
-                f"Failed to populate model choices dynamically; falling back to default models. Error: {e}",
-                exc_info=True,
+        from .llm_services import DefaultLLMService  # pylint: disable=import-outside-toplevel
+        llm_service = get_llm_service()
+        # Add warning if custom service is configured but using defaults
+        use_custom_service = get_site_configuration_value("ai_eval", "USE_CUSTOM_LLM_SERVICE")
+        if use_custom_service and llm_service and isinstance(llm_service, DefaultLLMService):
+            validation.add(
+                ValidationMessage(
+                    ValidationMessage.WARNING,
+                    _(
+                        "Custom LLM service is enabled but using default models due to configuration issues. "
+                        "Check logs for details."
+                    )
+                )
             )
-            fallback_models = SupportedModels.list()
-            choices = [{"display_name": m, "value": m} for m in fallback_models]
-            model_field = self.fields["model"]
-            model_field.values.clear()
-            model_field.values.extend(choices)
-            if not getattr(data, "model", None):
-                data.model = fallback_models[0]
-                self.model = fallback_models[0]
-            available_models = fallback_models
 
-        if not data.model or data.model not in available_models:
+        if not data.model:
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR,
-                    _("Model field is mandatory and must be one of %s")
-                    % ", ".join(available_models)
+                    _("Model field is mandatory - please select one from the dropdown.")
                 )
             )
 
         # Only run these checks for the default service
-        from .llm_services import DefaultLLMService  # pylint: disable=import-outside-toplevel
         if isinstance(llm_service, DefaultLLMService):
             if not self.get_model_api_key(data):
                 validation.add(

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -1,6 +1,7 @@
 """Base Xblock with AI evaluation."""
 from typing import Self
 
+import logging
 import pkg_resources
 
 from django.utils.translation import gettext_noop as _
@@ -11,10 +12,9 @@ from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xblock.validation import ValidationMessage
 
 from .compat import get_site_configuration_value
-from .llm import SupportedModels, get_llm_response, get_llm_service
-from .llm_services import DefaultLLMService
+from .supported_models import SupportedModels
+from .llm import get_llm_response, get_llm_service
 
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             # Set default if no model is selected
             if available_models and not getattr(data, "model", None):
                 data.model = available_models[0]
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error(
                 f"Failed to populate model choices dynamically; falling back to default models. Error: {e}",
                 exc_info=True,
@@ -155,16 +155,19 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR,
-                    _(f"Model field is mandatory and must be one of {', '.join(available_models)}")
+                    _("Model field is mandatory and must be one of %s")
+                    % ", ".join(available_models)
                 )
             )
 
         # Only run these checks for the default service
+        from .llm_services import DefaultLLMService  # pylint: disable=import-outside-toplevel
         if isinstance(llm_service, DefaultLLMService):
             if not self.get_model_api_key(data):
                 validation.add(
                     ValidationMessage(
-                        ValidationMessage.ERROR, _("Model API key is mandatory, if not set globally by your administrator.")
+                        ValidationMessage.ERROR,
+                        _("Model API key is mandatory, if not set globally by your administrator.")
                     )
                 )
 

--- a/ai_eval/coding_ai_eval.py
+++ b/ai_eval/coding_ai_eval.py
@@ -221,9 +221,9 @@ class CodingAIEvalXBlock(AIEvalXBlock):
         try:
             response = self.get_llm_response(messages)
         except Exception as e:
-            traceback.print_exc()
             logger.error(
-                f"Failed while making LLM request using model {self.model}. Eaised error type: {type(e)}, Error: {e}"
+                f"Failed while making LLM request using model {self.model}. Error: {e}",
+                exc_info=True,
             )
             raise JsonHandlerError(500, "A probem occured. Please retry.") from e
 

--- a/ai_eval/coding_ai_eval.py
+++ b/ai_eval/coding_ai_eval.py
@@ -1,7 +1,6 @@
 """Coding Xblock with AI evaluation."""
 
 import logging
-import traceback
 import pkg_resources
 
 from django.utils.translation import gettext_noop as _

--- a/ai_eval/llm.py
+++ b/ai_eval/llm.py
@@ -1,9 +1,9 @@
 """
 Integration with LLMs.
 """
-
+from django.conf import settings
 from enum import Enum
-from litellm import completion
+from .compat import get_site_configuration_value
 
 
 class SupportedModels(Enum):
@@ -22,15 +22,28 @@ class SupportedModels(Enum):
         return [str(m.value) for m in SupportedModels]
 
 
+def get_llm_service():
+    from .llm_services import DefaultLLMService, CustomLLMService
+    use_custom_service = get_site_configuration_value("ai_eval", "USE_CUSTOM_LLM_SERVICE")
+    if use_custom_service:
+        models_url     = get_site_configuration_value("ai_eval", "CUSTOM_LLM_MODELS_URL")
+        completions_url = get_site_configuration_value("ai_eval", "CUSTOM_LLM_COMPLETIONS_URL")
+        token_url      = get_site_configuration_value("ai_eval", "CUSTOM_LLM_TOKEN_URL")
+        client_id      = settings.CUSTOM_LLM_CLIENT_ID
+        client_secret  = settings.CUSTOM_LLM_CLIENT_SECRET
+        return CustomLLMService(models_url, completions_url, token_url, client_id, client_secret)
+    return DefaultLLMService()
+
+
 def get_llm_response(
-    model: SupportedModels, api_key: str, messages: list, api_base: str
+    model: str, api_key: str, messages: list, api_base: str
 ) -> str:
     """
-    Get LLm response.
+    Get LLM response, using either the default or custom service based on site configuration.
 
     Args:
-        model (SupportedModels): The model to use for generating the response. This should be an instance of
-            the SupportedModels enum, specifying which LLM model to call.
+        model (str): The model to use for generating the response. This can be either a supported
+            default model or a custom model name depending on the configured service.
         api_key (str): The API key required for authenticating with the LLM service. This key should be kept
             confidential and used to authorize requests to the service.
         messages (list): A list of message objects to be sent to the LLM. Each message should be a dictionary
@@ -56,11 +69,5 @@ def get_llm_response(
         str: The response text from the LLM. This is typically the generated output based on the provided
             messages.
     """
-    kwargs = {}
-    if api_base:
-        kwargs["api_base"] = api_base
-    return (
-        completion(model=model, api_key=api_key, messages=messages, **kwargs)
-        .choices[0]
-        .message.content
-    )
+    llm_service = get_llm_service()
+    return llm_service.get_response(model, api_key, messages, api_base)

--- a/ai_eval/llm.py
+++ b/ai_eval/llm.py
@@ -1,9 +1,12 @@
 """
 Integration with LLMs.
 """
+import logging
 from django.conf import settings
 from .compat import get_site_configuration_value
 from .llm_services import DefaultLLMService, CustomLLMService
+
+logger = logging.getLogger(__name__)
 
 
 def get_llm_service():
@@ -15,8 +18,33 @@ def get_llm_service():
         models_url = get_site_configuration_value("ai_eval", "CUSTOM_LLM_MODELS_URL")
         completions_url = get_site_configuration_value("ai_eval", "CUSTOM_LLM_COMPLETIONS_URL")
         token_url = get_site_configuration_value("ai_eval", "CUSTOM_LLM_TOKEN_URL")
-        client_id = settings.CUSTOM_LLM_CLIENT_ID
-        client_secret = settings.CUSTOM_LLM_CLIENT_SECRET
+
+        # Validate required configuration
+        missing_configs = []
+        if not models_url:
+            missing_configs.append("CUSTOM_LLM_MODELS_URL")
+        if not completions_url:
+            missing_configs.append("CUSTOM_LLM_COMPLETIONS_URL")
+        if not token_url:
+            missing_configs.append("CUSTOM_LLM_TOKEN_URL")
+
+        try:
+            client_id = settings.CUSTOM_LLM_CLIENT_ID
+            client_secret = settings.CUSTOM_LLM_CLIENT_SECRET
+            if not client_id:
+                missing_configs.append("CUSTOM_LLM_CLIENT_ID")
+            if not client_secret:
+                missing_configs.append("CUSTOM_LLM_CLIENT_SECRET")
+        except AttributeError:
+            missing_configs.extend(["CUSTOM_LLM_CLIENT_ID", "CUSTOM_LLM_CLIENT_SECRET"])
+
+        if missing_configs:
+            logger.warning(
+                f"Custom LLM service requested but missing configuration: {', '.join(missing_configs)}. "
+                f"Falling back to default service."
+            )
+            return DefaultLLMService()
+
         return CustomLLMService(models_url, completions_url, token_url, client_id, client_secret)
     return DefaultLLMService()
 

--- a/ai_eval/llm.py
+++ b/ai_eval/llm.py
@@ -2,35 +2,21 @@
 Integration with LLMs.
 """
 from django.conf import settings
-from enum import Enum
 from .compat import get_site_configuration_value
-
-
-class SupportedModels(Enum):
-    """
-    LLM Models supported by the CodingAIEvalXBlock and ShortAnswerAIEvalXBlock
-    """
-
-    GPT4O = "gpt-4o"
-    GPT4O_MINI = "gpt-4o-mini"
-    GEMINI_PRO = "gemini/gemini-pro"
-    CLAUDE_SONNET = "claude-3-5-sonnet-20240620"
-    LLAMA = "ollama/llama2"
-
-    @staticmethod
-    def list():
-        return [str(m.value) for m in SupportedModels]
+from .llm_services import DefaultLLMService, CustomLLMService
 
 
 def get_llm_service():
-    from .llm_services import DefaultLLMService, CustomLLMService
+    """
+    Get the CustomLLMService if configured otherwise return the default service.
+    """
     use_custom_service = get_site_configuration_value("ai_eval", "USE_CUSTOM_LLM_SERVICE")
     if use_custom_service:
-        models_url     = get_site_configuration_value("ai_eval", "CUSTOM_LLM_MODELS_URL")
+        models_url = get_site_configuration_value("ai_eval", "CUSTOM_LLM_MODELS_URL")
         completions_url = get_site_configuration_value("ai_eval", "CUSTOM_LLM_COMPLETIONS_URL")
-        token_url      = get_site_configuration_value("ai_eval", "CUSTOM_LLM_TOKEN_URL")
-        client_id      = settings.CUSTOM_LLM_CLIENT_ID
-        client_secret  = settings.CUSTOM_LLM_CLIENT_SECRET
+        token_url = get_site_configuration_value("ai_eval", "CUSTOM_LLM_TOKEN_URL")
+        client_id = settings.CUSTOM_LLM_CLIENT_ID
+        client_secret = settings.CUSTOM_LLM_CLIENT_SECRET
         return CustomLLMService(models_url, completions_url, token_url, client_id, client_secret)
     return DefaultLLMService()
 

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -33,9 +33,14 @@ class CustomLLMService(LLMServiceBase):
         self._expires_at     = 0
 
     def _fetch_token(self):
-        data = {'grant_type': 'client_credentials'}
-        auth = (self.client_id, self.client_secret)
-        response = requests.post(self.token_url, data=data, auth=auth)
+        data = {
+            'grant_type': 'client_credentials',
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'scope': 'ml.chatbot.query'
+        }
+        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+        response = requests.post(self.token_url, data=data, headers=headers)
         response.raise_for_status()
         token_data = response.json()
         self._access_token = token_data['access_token']

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -1,6 +1,10 @@
 import requests
+import logging
+
 from litellm import completion
 from .llm import SupportedModels
+
+logger = logging.getLogger(__name__)
 
 class LLMServiceBase:
     def get_response(self, model, api_key, messages, api_base):
@@ -77,7 +81,7 @@ class CustomLLMService(LLMServiceBase):
         response = requests.post(url, json=payload, headers=self._get_headers())
         response.raise_for_status()
         data = response.json()
-        # TODO: Adjust this if custom API returns the response differently
+        # Adjust this if custom API returns the response differently
         return data.get("response")
 
     def get_available_models(self):
@@ -94,5 +98,9 @@ class CustomLLMService(LLMServiceBase):
             elif isinstance(data, list):
                 return [str(m) for m in data]
             return []
-        except Exception:
+        except Exception as e:
+            logger.error(
+                f"Failed to fetch available models from custom LLM service. Error: {e}",
+                exc_info=True,
+            )
             return []

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -1,0 +1,93 @@
+import requests
+from litellm import completion
+from .llm import SupportedModels
+
+class LLMServiceBase:
+    def get_response(self, model, api_key, messages, api_base):
+        raise NotImplementedError
+
+    def get_available_models(self):
+        raise NotImplementedError
+
+class DefaultLLMService(LLMServiceBase):
+    def get_response(self, model, api_key, messages, api_base):
+        kwargs = {}
+        if api_base:
+            kwargs["api_base"] = api_base
+        return (
+            completion(model=model, api_key=api_key, messages=messages, **kwargs)
+            .choices[0]
+            .message.content
+        )
+    def get_available_models(self):
+        return [str(m.value) for m in SupportedModels]
+
+class CustomLLMService(LLMServiceBase):
+    def __init__(self, models_url, completions_url, token_url, client_id, client_secret):
+        self.models_url      = models_url
+        self.completions_url = completions_url
+        self.token_url       = token_url
+        self.client_id       = client_id
+        self.client_secret   = client_secret
+        self._access_token   = None
+        self._expires_at     = 0
+
+    def _fetch_token(self):
+        data = {'grant_type': 'client_credentials'}
+        auth = (self.client_id, self.client_secret)
+        response = requests.post(self.token_url, data=data, auth=auth)
+        response.raise_for_status()
+        token_data = response.json()
+        self._access_token = token_data['access_token']
+        expires_in = token_data.get('expires_in')
+        import time
+        if expires_in:
+            self._expires_at = time.time() + expires_in - 60
+        else:
+            self._expires_at = time.time() + 3300
+
+    def _ensure_token(self):
+        import time
+        if not self._access_token or time.time() >= self._expires_at:
+            self._fetch_token()
+
+    def _get_headers(self):
+        self._ensure_token()
+        return {'Authorization': f'Bearer {self._access_token}'}
+
+    def get_response(self, model, api_key, messages, api_base):
+        """
+        Send completion request to custom LLM endpoint.
+        """
+        url = self.completions_url
+        # Adjust the payload structure based on custom API requirements
+        prompt = " ".join(
+            f"{msg.get('role', '').capitalize()}: {msg.get('content', '').strip()}"
+            for msg in messages
+        )
+        payload = {
+            "model": str(model),
+            "prompt": prompt,
+        }
+        response = requests.post(url, json=payload, headers=self._get_headers())
+        response.raise_for_status()
+        data = response.json()
+        # TODO: Adjust this if custom API returns the response differently
+        return data.get("response")
+
+    def get_available_models(self):
+        url = self.models_url
+        try:
+            response = requests.get(url, headers=self._get_headers(), timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, dict):
+                if "models" in data and isinstance(data["models"], list):
+                    return [str(m) for m in data["models"]]
+                elif "data" in data and isinstance(data["data"], list):
+                    return [str(m.get("id", m)) for m in data["data"]]
+            elif isinstance(data, list):
+                return [str(m) for m in data]
+            return []
+        except Exception:
+            return []

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -9,6 +9,8 @@ from .supported_models import SupportedModels
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TOKEN_EXPIRES_IN = 3300
+
 
 class LLMServiceBase:
     """
@@ -69,7 +71,7 @@ class CustomLLMService(LLMServiceBase):
         if expires_in:
             self._expires_at = time.time() + expires_in - 60
         else:
-            self._expires_at = time.time() + 3300
+            self._expires_at = time.time() + DEFAULT_TOKEN_EXPIRES_IN
 
     def _ensure_token(self):
         if not self._access_token or time.time() >= self._expires_at:

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -1,19 +1,30 @@
-import requests
+"""LLM Services Module"""
+
 import logging
+import time
+import requests
 
 from litellm import completion
-from .llm import SupportedModels
+from .supported_models import SupportedModels
 
 logger = logging.getLogger(__name__)
 
+
 class LLMServiceBase:
+    """
+    Base class for llm service.
+    """
     def get_response(self, model, api_key, messages, api_base):
         raise NotImplementedError
 
     def get_available_models(self):
         raise NotImplementedError
 
+
 class DefaultLLMService(LLMServiceBase):
+    """
+    Default llm service.
+    """
     def get_response(self, model, api_key, messages, api_base):
         kwargs = {}
         if api_base:
@@ -23,20 +34,26 @@ class DefaultLLMService(LLMServiceBase):
             .choices[0]
             .message.content
         )
+
     def get_available_models(self):
         return [str(m.value) for m in SupportedModels]
 
-class CustomLLMService(LLMServiceBase):
-    def __init__(self, models_url, completions_url, token_url, client_id, client_secret):
-        self.models_url      = models_url
-        self.completions_url = completions_url
-        self.token_url       = token_url
-        self.client_id       = client_id
-        self.client_secret   = client_secret
-        self._access_token   = None
-        self._expires_at     = 0
 
-    def _fetch_token(self):
+class CustomLLMService(LLMServiceBase):
+    """
+    Custom llm service.
+    """
+    # pylint: disable=too-many-positional-arguments
+    def __init__(self, models_url, completions_url, token_url, client_id, client_secret):
+        self.models_url = models_url
+        self.completions_url = completions_url
+        self.token_url = token_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._access_token = None
+        self._expires_at = 0
+
+    def _fetch_token(self):  # pylint: disable=missing-function-docstring
         data = {
             'grant_type': 'client_credentials',
             'client_id': self.client_id,
@@ -44,19 +61,17 @@ class CustomLLMService(LLMServiceBase):
             'scope': 'ml.chatbot.query'
         }
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-        response = requests.post(self.token_url, data=data, headers=headers)
+        response = requests.post(self.token_url, data=data, headers=headers, timeout=10)
         response.raise_for_status()
         token_data = response.json()
         self._access_token = token_data['access_token']
         expires_in = token_data.get('expires_in')
-        import time
         if expires_in:
             self._expires_at = time.time() + expires_in - 60
         else:
             self._expires_at = time.time() + 3300
 
     def _ensure_token(self):
-        import time
         if not self._access_token or time.time() >= self._expires_at:
             self._fetch_token()
 
@@ -78,7 +93,7 @@ class CustomLLMService(LLMServiceBase):
             "model": str(model),
             "prompt": prompt,
         }
-        response = requests.post(url, json=payload, headers=self._get_headers())
+        response = requests.post(url, json=payload, headers=self._get_headers(), timeout=10)
         response.raise_for_status()
         data = response.json()
         # Adjust this if custom API returns the response differently
@@ -98,7 +113,7 @@ class CustomLLMService(LLMServiceBase):
             elif isinstance(data, list):
                 return [str(m) for m in data]
             return []
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error(
                 f"Failed to fetch available models from custom LLM service. Error: {e}",
                 exc_info=True,

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -104,20 +104,52 @@ class CustomLLMService(LLMServiceBase):
     def get_available_models(self):
         url = self.models_url
         try:
+            if not url:
+                logger.warning("CUSTOM_LLM_MODELS_URL not configured")
+                return []
+
             response = requests.get(url, headers=self._get_headers(), timeout=10)
             response.raise_for_status()
             data = response.json()
+
+            models = []
+
             if isinstance(data, dict):
-                if "models" in data and isinstance(data["models"], list):
-                    return [str(m) for m in data["models"]]
+                if "models" in data:
+                    if isinstance(data["models"], list):
+                        models = [str(m) for m in data["models"]]
+                    elif isinstance(data["models"], str):
+                        models = [str(data["models"])]
                 elif "data" in data and isinstance(data["data"], list):
-                    return [str(m.get("id", m)) for m in data["data"]]
+                    models = [str(m.get("id", str(m))) for m in data["data"]]
             elif isinstance(data, list):
-                return [str(m) for m in data]
+                models = [str(m) for m in data]
+            elif isinstance(data, str):
+                models = [str(data)]
+
+            # Filter out non-string model names and empty strings
+            models = [m for m in models if isinstance(m, str) and m.strip()]
+
+            if not models:
+                logger.warning("No valid models found in custom service response")
+
+            return models
+
+        except requests.exceptions.Timeout:
+            logger.error("Timeout fetching models from custom LLM service")
+            return []
+        except requests.exceptions.ConnectionError:
+            logger.error("Connection error fetching models from custom LLM service")
+            return []
+        except requests.exceptions.HTTPError as e:
+            logger.error(f"HTTP error fetching models: {e}")
+            return []
+        except ValueError as e:
+            logger.error(f"Invalid JSON response from custom LLM service: {e}")
             return []
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error(
-                f"Failed to fetch available models from custom LLM service. Error: {e}",
+                f"Unexpected error fetching models from custom LLM service: {e}",
                 exc_info=True,
             )
             return []

--- a/ai_eval/multiagent.py
+++ b/ai_eval/multiagent.py
@@ -16,7 +16,7 @@ from xblock.validation import ValidationMessage
 from web_fragments.fragment import Fragment
 
 from .base import AIEvalXBlock
-from .llm import SupportedModels
+from .supported_models import SupportedModels
 
 
 DEFAULT_SUPERVISOR_PROMPT = textwrap.dedent("""

--- a/ai_eval/shortanswer.py
+++ b/ai_eval/shortanswer.py
@@ -213,9 +213,9 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         try:
             response = self.get_llm_response(messages)
         except Exception as e:
-            traceback.print_exc()
             logger.error(
-                f"Failed while making LLM request using model {self.model}. Eaised error type: {type(e)}, Error: {e}"
+                f"Failed while making LLM request using model {self.model}. Error: {e}",
+                exc_info=True,
             )
             raise JsonHandlerError(500, "A probem occured. Please retry.") from e
 

--- a/ai_eval/shortanswer.py
+++ b/ai_eval/shortanswer.py
@@ -1,7 +1,6 @@
 """Short answers Xblock with AI evaluation."""
 
 import logging
-import traceback
 import urllib.parse
 import urllib.request
 from multiprocessing.dummy import Pool

--- a/ai_eval/supported_models.py
+++ b/ai_eval/supported_models.py
@@ -1,0 +1,20 @@
+"""Supported LLM model names and enumeration."""
+from enum import Enum
+
+
+class SupportedModels(Enum):
+    """
+    LLM Models supported by the CodingAIEvalXBlock, ShortAnswerAIEvalXBlock,
+    and MultiAgentAIEvalXBlock.
+    """
+
+    GPT4O = "gpt-4o"
+    GPT4O_MINI = "gpt-4o-mini"
+    GEMINI_PRO = "gemini/gemini-pro"
+    CLAUDE_SONNET = "claude-3-5-sonnet-20240620"
+    LLAMA = "ollama/llama2"
+
+    @staticmethod
+    def list():
+        """Return the list of supported model values."""
+        return [str(m.value) for m in SupportedModels]

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -16,7 +16,7 @@ from ai_eval import (
     ShortAnswerAIEvalXBlock,
 )
 from ai_eval.base import AIEvalXBlock
-from ai_eval.llm import SupportedModels
+from ai_eval.supported_models import SupportedModels
 
 
 @pytest.fixture

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,5 +3,5 @@
 
 django-statici18n
 XBlock[django]
-litellm
+litellm==0.14.0
 Jinja2

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,4 +4,6 @@
 django-statici18n
 XBlock[django]
 litellm==0.14.0
+openai==0.28.1
 Jinja2
+pydantic==2.11.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,45 +4,45 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.5.0
+aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.12.13
     # via litellm
 aiosignal==1.3.2
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   httpx
     #   openai
 appdirs==1.4.4
-    # via fs
+    # via
+    #   fs
+    #   litellm
 asgiref==3.8.1
     # via django
-attrs==25.1.0
-    # via
-    #   aiohttp
-    #   jsonschema
-    #   referencing
-boto3==1.37.9
+attrs==25.3.0
+    # via aiohttp
+boto3==1.38.36
     # via fs-s3fs
-botocore==1.37.9
+botocore==1.38.36
     # via
     #   boto3
     #   s3transfer
-certifi==2025.1.31
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
+    #   litellm
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.1
     # via litellm
 distro==1.9.0
     # via openai
-django==4.2.20
+django==4.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   django-appconf
@@ -52,9 +52,9 @@ django-appconf==1.1.0
     # via django-statici18n
 django-statici18n==2.6.0
     # via -r requirements/base.in
-filelock==3.17.0
+filelock==3.18.0
     # via huggingface-hub
-frozenlist==1.5.0
+frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
@@ -65,17 +65,17 @@ fs==2.4.16
     #   xblock
 fs-s3fs==1.1.1
     # via openedx-django-pyfs
-fsspec==2025.3.0
+fsspec==2025.5.1
     # via huggingface-hub
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.7
+hf-xet==1.1.3
+    # via huggingface-hub
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via
-    #   litellm
-    #   openai
-huggingface-hub==0.29.2
+    # via openai
+huggingface-hub==0.33.0
     # via tokenizers
 idna==3.10
     # via
@@ -83,82 +83,68 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via litellm
 jinja2==3.1.6
     # via
     #   -r requirements/base.in
     #   litellm
-jiter==0.8.2
+jiter==0.10.0
     # via openai
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.23.0
-    # via litellm
-jsonschema-specifications==2024.10.1
-    # via jsonschema
 lazy==1.6
     # via xblock
-litellm==1.63.3
+litellm==0.14.0
     # via -r requirements/base.in
-lxml==5.3.1
+lxml==5.4.0
     # via xblock
-mako==1.3.9
+mako==1.3.10
     # via xblock
 markupsafe==3.0.2
     # via
     #   jinja2
     #   mako
     #   xblock
-multidict==6.1.0
+multidict==6.4.4
     # via
     #   aiohttp
     #   yarl
-openai==1.65.5
+openai==1.86.0
     # via litellm
-openedx-django-pyfs==3.7.0
+openedx-django-pyfs==3.8.0
     # via xblock
-packaging==24.2
+packaging==25.0
     # via huggingface-hub
-propcache==0.3.0
+propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
-pydantic==2.10.6
-    # via
-    #   litellm
-    #   openai
-pydantic-core==2.27.2
+pydantic==2.11.7
+    # via openai
+pydantic-core==2.33.2
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   xblock
-python-dotenv==1.0.1
+python-dotenv==1.1.0
     # via litellm
-pytz==2025.1
+pytz==2025.2
     # via xblock
 pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   xblock
-referencing==0.36.2
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2024.11.6
     # via tiktoken
-requests==2.32.3
+requests==2.32.4
     # via
     #   huggingface-hub
     #   tiktoken
-rpds-py==0.23.1
-    # via
-    #   jsonschema
-    #   referencing
-s3transfer==0.11.4
+s3transfer==0.13.0
     # via boto3
 simplejson==3.20.1
     # via xblock
@@ -175,34 +161,36 @@ sqlparse==0.5.3
     # via django
 tiktoken==0.9.0
     # via litellm
-tokenizers==0.21.0
+tokenizers==0.21.1
     # via litellm
 tqdm==4.67.1
     # via
     #   huggingface-hub
     #   openai
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   anyio
     #   huggingface-hub
     #   openai
     #   pydantic
     #   pydantic-core
-    #   referencing
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via pydantic
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   botocore
     #   requests
-web-fragments==2.2.0
+web-fragments==3.1.0
     # via xblock
 webob==1.8.9
     # via xblock
-xblock[django]==5.1.2
+xblock[django]==5.2.0
     # via -r requirements/base.in
-yarl==1.18.3
+yarl==1.20.1
     # via aiohttp
-zipp==3.21.0
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,45 +6,39 @@
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.13
-    # via litellm
-aiosignal==1.3.2
+aiohttp==3.12.15
+    # via
+    #   litellm
+    #   openai
+aiosignal==1.4.0
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.9.0
-    # via
-    #   httpx
-    #   openai
 appdirs==1.4.4
     # via
     #   fs
     #   litellm
-asgiref==3.8.1
+asgiref==3.9.1
     # via django
 attrs==25.3.0
     # via aiohttp
-boto3==1.38.36
+boto3==1.40.0
     # via fs-s3fs
-botocore==1.38.36
+botocore==1.40.0
     # via
     #   boto3
     #   s3transfer
 certifi==2023.11.17
     # via
-    #   httpcore
-    #   httpx
     #   litellm
     #   requests
 charset-normalizer==3.4.2
     # via requests
 click==8.2.1
     # via litellm
-distro==1.9.0
-    # via openai
 django==4.2.23
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   django-appconf
     #   django-statici18n
     #   openedx-django-pyfs
@@ -65,22 +59,14 @@ fs==2.4.16
     #   xblock
 fs-s3fs==1.1.1
     # via openedx-django-pyfs
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via huggingface-hub
-h11==0.16.0
-    # via httpcore
-hf-xet==1.1.3
+hf-xet==1.1.5
     # via huggingface-hub
-httpcore==1.0.9
-    # via httpx
-httpx==0.28.1
-    # via openai
-huggingface-hub==0.33.0
+huggingface-hub==0.34.3
     # via tokenizers
 idna==3.10
     # via
-    #   anyio
-    #   httpx
     #   requests
     #   yarl
 importlib-metadata==8.7.0
@@ -89,8 +75,6 @@ jinja2==3.1.6
     # via
     #   -r requirements/base.in
     #   litellm
-jiter==0.10.0
-    # via openai
 jmespath==1.0.1
     # via
     #   boto3
@@ -99,7 +83,7 @@ lazy==1.6
     # via xblock
 litellm==0.14.0
     # via -r requirements/base.in
-lxml==5.4.0
+lxml==6.0.0
     # via xblock
 mako==1.3.10
     # via xblock
@@ -108,12 +92,14 @@ markupsafe==3.0.2
     #   jinja2
     #   mako
     #   xblock
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl
-openai==1.86.0
-    # via litellm
+openai==0.28.1
+    # via
+    #   -r requirements/base.in
+    #   litellm
 openedx-django-pyfs==3.8.0
     # via xblock
 packaging==25.0
@@ -123,14 +109,14 @@ propcache==0.3.2
     #   aiohttp
     #   yarl
 pydantic==2.11.7
-    # via openai
+    # via -r requirements/base.in
 pydantic-core==2.33.2
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   xblock
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via litellm
 pytz==2025.2
     # via xblock
@@ -138,13 +124,14 @@ pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   xblock
-regex==2024.11.6
+regex==2025.7.34
     # via tiktoken
 requests==2.32.4
     # via
     #   huggingface-hub
+    #   openai
     #   tiktoken
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 simplejson==3.20.1
     # via xblock
@@ -153,33 +140,27 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   anyio
-    #   openai
 sqlparse==0.5.3
     # via django
 tiktoken==0.9.0
     # via litellm
-tokenizers==0.21.1
+tokenizers==0.21.4
     # via litellm
 tqdm==4.67.1
     # via
     #   huggingface-hub
     #   openai
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
-    #   anyio
+    #   aiosignal
     #   huggingface-hub
-    #   openai
     #   pydantic
     #   pydantic-core
     #   typing-inspection
 typing-inspection==0.4.1
     # via pydantic
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   botocore
     #   requests
 web-fragments==3.1.0

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,3 +2,5 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
+openai==0.28.1
+certifi==2023.11.17

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.5.2
+cachetools==6.0.0
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,23 +12,23 @@ colorama==0.4.6
     # via tox
 distlib==0.3.9
     # via virtualenv
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   tox
     #   virtualenv
-packaging==24.2
+packaging==25.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via tox
-pyproject-api==1.9.0
+pyproject-api==1.9.1
     # via tox
-tox==4.24.2
+tox==4.26.0
     # via -r requirements/ci.in
-virtualenv==20.29.3
+virtualenv==20.31.2
     # via tox

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,18 +4,46 @@
 #
 #    make upgrade
 #
-cachetools==6.0.0
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.12.15
+    # via openai
+aiosignal==1.4.0
+    # via aiohttp
+attrs==25.3.0
+    # via aiohttp
+cachetools==6.1.0
     # via tox
+certifi==2023.11.17
+    # via
+    #   -r requirements/ci.in
+    #   requests
 chardet==5.2.0
     # via tox
+charset-normalizer==3.4.2
+    # via requests
 colorama==0.4.6
     # via tox
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 filelock==3.18.0
     # via
     #   tox
     #   virtualenv
+frozenlist==1.7.0
+    # via
+    #   aiohttp
+    #   aiosignal
+idna==3.10
+    # via
+    #   requests
+    #   yarl
+multidict==6.6.3
+    # via
+    #   aiohttp
+    #   yarl
+openai==0.28.1
+    # via -r requirements/ci.in
 packaging==25.0
     # via
     #   pyproject-api
@@ -26,9 +54,23 @@ platformdirs==4.3.8
     #   virtualenv
 pluggy==1.6.0
     # via tox
+propcache==0.3.2
+    # via
+    #   aiohttp
+    #   yarl
 pyproject-api==1.9.1
     # via tox
-tox==4.26.0
+requests==2.32.4
+    # via openai
+tox==4.28.4
     # via -r requirements/ci.in
-virtualenv==20.31.2
+tqdm==4.67.1
+    # via openai
+typing-extensions==4.14.1
+    # via aiosignal
+urllib3==2.5.0
+    # via requests
+virtualenv==20.32.0
     # via tox
+yarl==1.20.1
+    # via aiohttp

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.5.0
+aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.12.13
     # via
     #   -r requirements/quality.txt
     #   litellm
@@ -20,7 +20,7 @@ annotated-types==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -r requirements/quality.txt
     #   httpx
@@ -29,6 +29,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/quality.txt
     #   fs
+    #   litellm
 arrow==1.3.0
     # via
     #   -r requirements/quality.txt
@@ -37,26 +38,24 @@ asgiref==3.8.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==3.3.9
+astroid==3.3.10
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-    #   jsonschema
-    #   referencing
 binaryornot==0.4.4
     # via
     #   -r requirements/quality.txt
     #   cookiecutter
-boto3==1.37.9
+boto3==1.38.36
     # via
     #   -r requirements/quality.txt
     #   fs-s3fs
-botocore==1.37.9
+botocore==1.38.36
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -65,15 +64,16 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==5.5.2
+cachetools==6.0.0
     # via
     #   -r requirements/ci.txt
     #   tox
-certifi==2025.1.31
+certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
     #   httpcore
     #   httpx
+    #   litellm
     #   requests
 chardet==5.2.0
     # via
@@ -81,11 +81,11 @@ chardet==5.2.0
     #   -r requirements/quality.txt
     #   binaryornot
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.1.8
+click==8.2.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -99,7 +99,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -111,13 +111,13 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-coverage[toml]==7.6.12
+coverage[toml]==7.9.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
 ddt==1.7.2
     # via -r requirements/quality.txt
-dill==0.3.9
+dill==0.4.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -129,7 +129,7 @@ distro==1.9.0
     # via
     #   -r requirements/quality.txt
     #   openai
-django==4.2.20
+django==4.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -144,18 +144,18 @@ django-appconf==1.1.0
     #   django-statici18n
 django-statici18n==2.6.0
     # via -r requirements/quality.txt
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.9.0
     # via -r requirements/quality.txt
 edx-lint==5.6.0
     # via -r requirements/quality.txt
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   huggingface-hub
     #   tox
     #   virtualenv
-frozenlist==1.5.0
+frozenlist==1.7.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
@@ -171,24 +171,27 @@ fs-s3fs==1.1.1
     #   -r requirements/quality.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.3.0
+fsspec==2025.5.1
     # via
     #   -r requirements/quality.txt
     #   huggingface-hub
-h11==0.14.0
+h11==0.16.0
     # via
     #   -r requirements/quality.txt
     #   httpcore
-httpcore==1.0.7
+hf-xet==1.1.3
+    # via
+    #   -r requirements/quality.txt
+    #   huggingface-hub
+httpcore==1.0.9
     # via
     #   -r requirements/quality.txt
     #   httpx
 httpx==0.28.1
     # via
     #   -r requirements/quality.txt
-    #   litellm
     #   openai
-huggingface-hub==0.29.2
+huggingface-hub==0.33.0
     # via
     #   -r requirements/quality.txt
     #   tokenizers
@@ -199,11 +202,11 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via
     #   -r requirements/quality.txt
     #   litellm
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -217,7 +220,7 @@ jinja2==3.1.6
     #   code-annotations
     #   cookiecutter
     #   litellm
-jiter==0.8.2
+jiter==0.10.0
     # via
     #   -r requirements/quality.txt
     #   openai
@@ -226,32 +229,24 @@ jmespath==1.0.1
     #   -r requirements/quality.txt
     #   boto3
     #   botocore
-jsonschema==4.23.0
-    # via
-    #   -r requirements/quality.txt
-    #   litellm
-jsonschema-specifications==2024.10.1
-    # via
-    #   -r requirements/quality.txt
-    #   jsonschema
 lazy==1.6
     # via
     #   -r requirements/quality.txt
     #   xblock
-litellm==1.63.3
+litellm==0.14.0
     # via -r requirements/quality.txt
-lxml[html-clean]==5.3.1
+lxml[html-clean]==5.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
     #   xblock-sdk
-lxml-html-clean==0.4.1
+lxml-html-clean==0.4.2
     # via
     #   -r requirements/quality.txt
     #   lxml
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/quality.txt
     #   xblock
@@ -275,20 +270,20 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/quality.txt
-multidict==6.1.0
+multidict==6.4.4
     # via
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-openai==1.65.5
+openai==1.86.0
     # via
     #   -r requirements/quality.txt
     #   litellm
-openedx-django-pyfs==3.7.0
+openedx-django-pyfs==3.8.0
     # via
     #   -r requirements/quality.txt
     #   xblock
-packaging==24.2
+packaging==25.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -308,44 +303,45 @@ pbr==6.1.1
     #   stevedore
 pip-tools==7.4.1
     # via -r requirements/pip-tools.txt
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest
+    #   pytest-cov
     #   tox
 polib==1.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-i18n-tools
-propcache==0.3.0
+propcache==0.3.2
     # via
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/quality.txt
-pydantic==2.10.6
+pydantic==2.11.7
     # via
     #   -r requirements/quality.txt
-    #   litellm
     #   openai
-pydantic-core==2.27.2
+pydantic-core==2.33.2
     # via
     #   -r requirements/quality.txt
     #   pydantic
 pygments==2.19.1
     # via
     #   -r requirements/quality.txt
+    #   pytest
     #   rich
-pylint==3.3.5
+pylint==3.3.7
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -369,7 +365,7 @@ pypng==0.20220715.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-pyproject-api==1.9.0
+pyproject-api==1.9.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -378,14 +374,14 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.3.5
+pytest==8.4.0
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements/quality.txt
-pytest-django==4.10.0
+pytest-django==4.11.1
     # via -r requirements/quality.txt
 python-dateutil==2.9.0.post0
     # via
@@ -393,7 +389,7 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
     #   xblock
-python-dotenv==1.0.1
+python-dotenv==1.1.0
     # via
     #   -r requirements/quality.txt
     #   litellm
@@ -402,7 +398,7 @@ python-slugify==8.0.4
     #   -r requirements/quality.txt
     #   code-annotations
     #   cookiecutter
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/quality.txt
     #   xblock
@@ -414,32 +410,22 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   huggingface-hub
     #   xblock
-referencing==0.36.2
-    # via
-    #   -r requirements/quality.txt
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2024.11.6
     # via
     #   -r requirements/quality.txt
     #   tiktoken
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements/quality.txt
     #   cookiecutter
     #   huggingface-hub
     #   tiktoken
     #   xblock-sdk
-rich==13.9.4
+rich==14.0.0
     # via
     #   -r requirements/quality.txt
     #   cookiecutter
-rpds-py==0.23.1
-    # via
-    #   -r requirements/quality.txt
-    #   jsonschema
-    #   referencing
-s3transfer==0.11.4
+s3transfer==0.13.0
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -476,26 +462,26 @@ tiktoken==0.9.0
     # via
     #   -r requirements/quality.txt
     #   litellm
-tokenizers==0.21.0
+tokenizers==0.21.1
     # via
     #   -r requirements/quality.txt
     #   litellm
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.24.2
+tox==4.26.0
     # via -r requirements/ci.txt
 tqdm==4.67.1
     # via
     #   -r requirements/quality.txt
     #   huggingface-hub
     #   openai
-types-python-dateutil==2.9.0.20241206
+types-python-dateutil==2.9.0.20250516
     # via
     #   -r requirements/quality.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -r requirements/quality.txt
     #   anyio
@@ -503,18 +489,22 @@ typing-extensions==4.12.2
     #   openai
     #   pydantic
     #   pydantic-core
-    #   referencing
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   pydantic
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   botocore
     #   requests
-virtualenv==20.29.3
+virtualenv==20.31.2
     # via
     #   -r requirements/ci.txt
     #   tox
-web-fragments==2.2.0
+web-fragments==3.1.0
     # via
     #   -r requirements/quality.txt
     #   xblock
@@ -528,17 +518,17 @@ wheel==0.45.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-xblock[django]==5.1.2
+xblock[django]==5.2.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-xblock-sdk==0.12.0
+xblock-sdk==0.13.0
     # via -r requirements/quality.txt
-yarl==1.18.3
+yarl==1.20.1
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-zipp==3.21.0
+zipp==3.23.0
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,25 +6,24 @@
 #
 aiohappyeyeballs==2.6.1
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   litellm
-aiosignal==1.3.2
+    #   openai
+aiosignal==1.4.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
 annotated-types==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pydantic
-anyio==4.9.0
-    # via
-    #   -r requirements/quality.txt
-    #   httpx
-    #   openai
 appdirs==1.4.4
     # via
     #   -r requirements/quality.txt
@@ -34,28 +33,29 @@ arrow==1.3.0
     # via
     #   -r requirements/quality.txt
     #   cookiecutter
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==3.3.10
+astroid==3.3.11
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
 attrs==25.3.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
 binaryornot==0.4.4
     # via
     #   -r requirements/quality.txt
     #   cookiecutter
-boto3==1.38.36
+boto3==1.40.0
     # via
     #   -r requirements/quality.txt
     #   fs-s3fs
-botocore==1.38.36
+botocore==1.40.0
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -64,15 +64,14 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==6.0.0
+cachetools==6.1.0
     # via
     #   -r requirements/ci.txt
     #   tox
 certifi==2023.11.17
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   httpcore
-    #   httpx
     #   litellm
     #   requests
 chardet==5.2.0
@@ -83,6 +82,7 @@ chardet==5.2.0
     #   tox
 charset-normalizer==3.4.2
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.2.1
@@ -111,7 +111,7 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
-coverage[toml]==7.9.1
+coverage[toml]==7.10.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -121,17 +121,13 @@ dill==0.4.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-distro==1.9.0
-    # via
-    #   -r requirements/quality.txt
-    #   openai
 django==4.2.23
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   django-appconf
     #   django-statici18n
@@ -157,6 +153,7 @@ filelock==3.18.0
     #   virtualenv
 frozenlist==1.7.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
     #   aiosignal
@@ -171,35 +168,22 @@ fs-s3fs==1.1.1
     #   -r requirements/quality.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via
     #   -r requirements/quality.txt
     #   huggingface-hub
-h11==0.16.0
-    # via
-    #   -r requirements/quality.txt
-    #   httpcore
-hf-xet==1.1.3
+hf-xet==1.1.5
     # via
     #   -r requirements/quality.txt
     #   huggingface-hub
-httpcore==1.0.9
-    # via
-    #   -r requirements/quality.txt
-    #   httpx
-httpx==0.28.1
-    # via
-    #   -r requirements/quality.txt
-    #   openai
-huggingface-hub==0.33.0
+huggingface-hub==0.34.3
     # via
     #   -r requirements/quality.txt
     #   tokenizers
 idna==3.10
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   anyio
-    #   httpx
     #   requests
     #   yarl
 importlib-metadata==8.7.0
@@ -220,10 +204,6 @@ jinja2==3.1.6
     #   code-annotations
     #   cookiecutter
     #   litellm
-jiter==0.10.0
-    # via
-    #   -r requirements/quality.txt
-    #   openai
 jmespath==1.0.1
     # via
     #   -r requirements/quality.txt
@@ -235,7 +215,7 @@ lazy==1.6
     #   xblock
 litellm==0.14.0
     # via -r requirements/quality.txt
-lxml[html-clean]==5.4.0
+lxml[html-clean]==6.0.0
     # via
     #   -r requirements/quality.txt
     #   edx-i18n-tools
@@ -270,13 +250,15 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/quality.txt
-multidict==6.4.4
+multidict==6.6.3
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-openai==1.86.0
+openai==0.28.1
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   litellm
 openedx-django-pyfs==3.8.0
@@ -301,7 +283,7 @@ pbr==6.1.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==7.4.1
+pip-tools==7.5.0
     # via -r requirements/pip-tools.txt
 platformdirs==4.3.8
     # via
@@ -323,20 +305,19 @@ polib==1.2.0
     #   edx-i18n-tools
 propcache==0.3.2
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/quality.txt
 pydantic==2.11.7
-    # via
-    #   -r requirements/quality.txt
-    #   openai
+    # via -r requirements/quality.txt
 pydantic-core==2.33.2
     # via
     #   -r requirements/quality.txt
     #   pydantic
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -356,7 +337,7 @@ pylint-django==2.6.1
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   -r requirements/quality.txt
     #   pylint-celery
@@ -374,7 +355,7 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.4.0
+pytest==8.4.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -389,7 +370,7 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
     #   xblock
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via
     #   -r requirements/quality.txt
     #   litellm
@@ -410,22 +391,24 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   huggingface-hub
     #   xblock
-regex==2024.11.6
+regex==2025.7.34
     # via
     #   -r requirements/quality.txt
     #   tiktoken
 requests==2.32.4
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   cookiecutter
     #   huggingface-hub
+    #   openai
     #   tiktoken
     #   xblock-sdk
-rich==14.0.0
+rich==14.1.0
     # via
     #   -r requirements/quality.txt
     #   cookiecutter
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -441,11 +424,6 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/quality.txt
-    #   anyio
-    #   openai
 sqlparse==0.5.3
     # via
     #   -r requirements/quality.txt
@@ -462,7 +440,7 @@ tiktoken==0.9.0
     # via
     #   -r requirements/quality.txt
     #   litellm
-tokenizers==0.21.1
+tokenizers==0.21.4
     # via
     #   -r requirements/quality.txt
     #   litellm
@@ -470,23 +448,24 @@ tomlkit==0.13.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.26.0
+tox==4.28.4
     # via -r requirements/ci.txt
 tqdm==4.67.1
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   huggingface-hub
     #   openai
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250708
     # via
     #   -r requirements/quality.txt
     #   arrow
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   anyio
+    #   aiosignal
     #   huggingface-hub
-    #   openai
     #   pydantic
     #   pydantic-core
     #   typing-inspection
@@ -494,13 +473,13 @@ typing-inspection==0.4.1
     # via
     #   -r requirements/quality.txt
     #   pydantic
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   botocore
     #   requests
-virtualenv==20.31.2
+virtualenv==20.32.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -526,6 +505,7 @@ xblock-sdk==0.13.0
     # via -r requirements/quality.txt
 yarl==1.20.1
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
 zipp==3.23.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,9 +6,9 @@
 #
 build==1.2.2.post1
     # via pip-tools
-click==8.1.8
+click==8.2.1
     # via pip-tools
-packaging==24.2
+packaging==25.0
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.2.1
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.4.1
+pip-tools==7.5.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in
 setuptools==80.9.0
     # via -r requirements/pip.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==76.0.0
+setuptools==80.9.0
     # via -r requirements/pip.in

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -5,3 +5,4 @@
 
 edx-lint                  # edX pylint rules and plugins
 pycodestyle               # PEP 8 compliance validation
+openai==0.28.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.5.0
+aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/test.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.12.13
     # via
     #   -r requirements/test.txt
     #   litellm
@@ -20,7 +20,7 @@ annotated-types==0.7.0
     # via
     #   -r requirements/test.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -r requirements/test.txt
     #   httpx
@@ -29,6 +29,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   fs
+    #   litellm
 arrow==1.3.0
     # via
     #   -r requirements/test.txt
@@ -37,44 +38,43 @@ asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.9
+astroid==3.3.10
     # via
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
-    #   jsonschema
-    #   referencing
 binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-boto3==1.37.9
+boto3==1.38.36
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.37.9
+botocore==1.38.36
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-certifi==2025.1.31
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   httpcore
     #   httpx
+    #   litellm
     #   requests
 chardet==5.2.0
     # via
     #   -r requirements/test.txt
     #   binaryornot
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.1.8
+click==8.2.1
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -84,25 +84,25 @@ click==8.1.8
     #   litellm
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via edx-lint
 cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.6.12
+coverage[toml]==7.9.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.7.2
     # via -r requirements/test.txt
-dill==0.3.9
+dill==0.4.0
     # via pylint
 distro==1.9.0
     # via
     #   -r requirements/test.txt
     #   openai
-django==4.2.20
+django==4.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -117,15 +117,15 @@ django-appconf==1.1.0
     #   django-statici18n
 django-statici18n==2.6.0
     # via -r requirements/test.txt
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.9.0
     # via -r requirements/test.txt
 edx-lint==5.6.0
     # via -r requirements/quality.in
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
-frozenlist==1.5.0
+frozenlist==1.7.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -141,24 +141,27 @@ fs-s3fs==1.1.1
     #   -r requirements/test.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.3.0
+fsspec==2025.5.1
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
-h11==0.14.0
+h11==0.16.0
     # via
     #   -r requirements/test.txt
     #   httpcore
-httpcore==1.0.7
+hf-xet==1.1.3
+    # via
+    #   -r requirements/test.txt
+    #   huggingface-hub
+httpcore==1.0.9
     # via
     #   -r requirements/test.txt
     #   httpx
 httpx==0.28.1
     # via
     #   -r requirements/test.txt
-    #   litellm
     #   openai
-huggingface-hub==0.29.2
+huggingface-hub==0.33.0
     # via
     #   -r requirements/test.txt
     #   tokenizers
@@ -169,11 +172,11 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via
     #   -r requirements/test.txt
     #   litellm
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -185,7 +188,7 @@ jinja2==3.1.6
     #   code-annotations
     #   cookiecutter
     #   litellm
-jiter==0.8.2
+jiter==0.10.0
     # via
     #   -r requirements/test.txt
     #   openai
@@ -194,32 +197,24 @@ jmespath==1.0.1
     #   -r requirements/test.txt
     #   boto3
     #   botocore
-jsonschema==4.23.0
-    # via
-    #   -r requirements/test.txt
-    #   litellm
-jsonschema-specifications==2024.10.1
-    # via
-    #   -r requirements/test.txt
-    #   jsonschema
 lazy==1.6
     # via
     #   -r requirements/test.txt
     #   xblock
-litellm==1.63.3
+litellm==0.14.0
     # via -r requirements/test.txt
-lxml[html-clean]==5.3.1
+lxml[html-clean]==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
     #   xblock-sdk
-lxml-html-clean==0.4.1
+lxml-html-clean==0.4.2
     # via
     #   -r requirements/test.txt
     #   lxml
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -241,20 +236,20 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/test.txt
-multidict==6.1.0
+multidict==6.4.4
     # via
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-openai==1.65.5
+openai==1.86.0
     # via
     #   -r requirements/test.txt
     #   litellm
-openedx-django-pyfs==3.7.0
+openedx-django-pyfs==3.8.0
     # via
     #   -r requirements/test.txt
     #   xblock
-packaging==24.2
+packaging==25.0
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
@@ -265,37 +260,38 @@ path==16.16.0
     #   edx-i18n-tools
 pbr==6.1.1
     # via stevedore
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via pylint
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -r requirements/test.txt
     #   pytest
+    #   pytest-cov
 polib==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
-propcache==0.3.0
+propcache==0.3.2
     # via
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/quality.in
-pydantic==2.10.6
+pydantic==2.11.7
     # via
     #   -r requirements/test.txt
-    #   litellm
     #   openai
-pydantic-core==2.27.2
+pydantic-core==2.33.2
     # via
     #   -r requirements/test.txt
     #   pydantic
 pygments==2.19.1
     # via
     #   -r requirements/test.txt
+    #   pytest
     #   rich
-pylint==3.3.5
+pylint==3.3.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -313,14 +309,14 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pytest==8.3.5
+pytest==8.4.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements/test.txt
-pytest-django==4.10.0
+pytest-django==4.11.1
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
@@ -328,7 +324,7 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
     #   xblock
-python-dotenv==1.0.1
+python-dotenv==1.1.0
     # via
     #   -r requirements/test.txt
     #   litellm
@@ -337,7 +333,7 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -349,32 +345,22 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   huggingface-hub
     #   xblock
-referencing==0.36.2
-    # via
-    #   -r requirements/test.txt
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2024.11.6
     # via
     #   -r requirements/test.txt
     #   tiktoken
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
     #   huggingface-hub
     #   tiktoken
     #   xblock-sdk
-rich==13.9.4
+rich==14.0.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-rpds-py==0.23.1
-    # via
-    #   -r requirements/test.txt
-    #   jsonschema
-    #   referencing
-s3transfer==0.11.4
+s3transfer==0.13.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -409,22 +395,22 @@ tiktoken==0.9.0
     # via
     #   -r requirements/test.txt
     #   litellm
-tokenizers==0.21.0
+tokenizers==0.21.1
     # via
     #   -r requirements/test.txt
     #   litellm
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via pylint
 tqdm==4.67.1
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
     #   openai
-types-python-dateutil==2.9.0.20241206
+types-python-dateutil==2.9.0.20250516
     # via
     #   -r requirements/test.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -r requirements/test.txt
     #   anyio
@@ -432,14 +418,18 @@ typing-extensions==4.12.2
     #   openai
     #   pydantic
     #   pydantic-core
-    #   referencing
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   botocore
     #   requests
-web-fragments==2.2.0
+web-fragments==3.1.0
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -449,17 +439,17 @@ webob==1.8.9
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-xblock[django]==5.1.2
+xblock[django]==5.2.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-xblock-sdk==0.12.0
+xblock-sdk==0.13.0
     # via -r requirements/test.txt
-yarl==1.18.3
+yarl==1.20.1
     # via
     #   -r requirements/test.txt
     #   aiohttp
-zipp==3.21.0
+zipp==3.23.0
     # via
     #   -r requirements/test.txt
     #   importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,11 +8,12 @@ aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/test.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   -r requirements/test.txt
     #   litellm
-aiosignal==1.3.2
+    #   openai
+aiosignal==1.4.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -20,11 +21,6 @@ annotated-types==0.7.0
     # via
     #   -r requirements/test.txt
     #   pydantic
-anyio==4.9.0
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-    #   openai
 appdirs==1.4.4
     # via
     #   -r requirements/test.txt
@@ -34,11 +30,11 @@ arrow==1.3.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.10
+astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
@@ -50,11 +46,11 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-boto3==1.38.36
+boto3==1.40.0
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.38.36
+botocore==1.40.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -62,8 +58,6 @@ botocore==1.38.36
 certifi==2023.11.17
     # via
     #   -r requirements/test.txt
-    #   httpcore
-    #   httpx
     #   litellm
     #   requests
 chardet==5.2.0
@@ -90,7 +84,7 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.9.1
+coverage[toml]==7.10.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -98,13 +92,9 @@ ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.4.0
     # via pylint
-distro==1.9.0
-    # via
-    #   -r requirements/test.txt
-    #   openai
 django==4.2.23
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-appconf
     #   django-statici18n
@@ -141,35 +131,21 @@ fs-s3fs==1.1.1
     #   -r requirements/test.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
-h11==0.16.0
-    # via
-    #   -r requirements/test.txt
-    #   httpcore
-hf-xet==1.1.3
+hf-xet==1.1.5
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
-httpcore==1.0.9
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-httpx==0.28.1
-    # via
-    #   -r requirements/test.txt
-    #   openai
-huggingface-hub==0.33.0
+huggingface-hub==0.34.3
     # via
     #   -r requirements/test.txt
     #   tokenizers
 idna==3.10
     # via
     #   -r requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
     #   yarl
 importlib-metadata==8.7.0
@@ -188,10 +164,6 @@ jinja2==3.1.6
     #   code-annotations
     #   cookiecutter
     #   litellm
-jiter==0.10.0
-    # via
-    #   -r requirements/test.txt
-    #   openai
 jmespath==1.0.1
     # via
     #   -r requirements/test.txt
@@ -203,7 +175,7 @@ lazy==1.6
     #   xblock
 litellm==0.14.0
     # via -r requirements/test.txt
-lxml[html-clean]==5.4.0
+lxml[html-clean]==6.0.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
@@ -236,13 +208,14 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/test.txt
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-openai==1.86.0
+openai==0.28.1
     # via
+    #   -r requirements/quality.in
     #   -r requirements/test.txt
     #   litellm
 openedx-django-pyfs==3.8.0
@@ -276,17 +249,15 @@ propcache==0.3.2
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/quality.in
 pydantic==2.11.7
-    # via
-    #   -r requirements/test.txt
-    #   openai
+    # via -r requirements/test.txt
 pydantic-core==2.33.2
     # via
     #   -r requirements/test.txt
     #   pydantic
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -301,7 +272,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.6.1
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
@@ -309,7 +280,7 @@ pypng==0.20220715.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-pytest==8.4.0
+pytest==8.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -324,7 +295,7 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
     #   xblock
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via
     #   -r requirements/test.txt
     #   litellm
@@ -345,7 +316,7 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   huggingface-hub
     #   xblock
-regex==2024.11.6
+regex==2025.7.34
     # via
     #   -r requirements/test.txt
     #   tiktoken
@@ -354,13 +325,14 @@ requests==2.32.4
     #   -r requirements/test.txt
     #   cookiecutter
     #   huggingface-hub
+    #   openai
     #   tiktoken
     #   xblock-sdk
-rich==14.0.0
+rich==14.1.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -376,11 +348,6 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/test.txt
-    #   anyio
-    #   openai
 sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
@@ -395,7 +362,7 @@ tiktoken==0.9.0
     # via
     #   -r requirements/test.txt
     #   litellm
-tokenizers==0.21.1
+tokenizers==0.21.4
     # via
     #   -r requirements/test.txt
     #   litellm
@@ -406,16 +373,15 @@ tqdm==4.67.1
     #   -r requirements/test.txt
     #   huggingface-hub
     #   openai
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250708
     # via
     #   -r requirements/test.txt
     #   arrow
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/test.txt
-    #   anyio
+    #   aiosignal
     #   huggingface-hub
-    #   openai
     #   pydantic
     #   pydantic-core
     #   typing-inspection
@@ -423,9 +389,8 @@ typing-inspection==0.4.1
     # via
     #   -r requirements/test.txt
     #   pydantic
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   botocore
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-aiohappyeyeballs==2.5.0
+aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.12.13
     # via
     #   -r requirements/base.txt
     #   litellm
@@ -20,7 +20,7 @@ annotated-types==0.7.0
     # via
     #   -r requirements/base.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -r requirements/base.txt
     #   httpx
@@ -29,49 +29,49 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
+    #   litellm
 arrow==1.3.0
     # via cookiecutter
 asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
-    #   jsonschema
-    #   referencing
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.37.9
+boto3==1.38.36
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.37.9
+botocore==1.38.36
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-certifi==2025.1.31
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   httpcore
     #   httpx
+    #   litellm
     #   requests
 chardet==5.2.0
     # via binaryornot
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.8
+click==8.2.1
     # via
     #   -r requirements/base.txt
     #   cookiecutter
     #   litellm
 cookiecutter==2.6.0
     # via xblock-sdk
-coverage[toml]==7.6.12
+coverage[toml]==7.9.1
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
@@ -93,13 +93,13 @@ django-appconf==1.1.0
     #   django-statici18n
 django-statici18n==2.6.0
     # via -r requirements/base.txt
-edx-i18n-tools==1.6.3
+edx-i18n-tools==1.9.0
     # via -r requirements/test.in
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
-frozenlist==1.5.0
+frozenlist==1.7.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -115,24 +115,27 @@ fs-s3fs==1.1.1
     #   -r requirements/base.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.3.0
+fsspec==2025.5.1
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
-h11==0.14.0
+h11==0.16.0
     # via
     #   -r requirements/base.txt
     #   httpcore
-httpcore==1.0.7
+hf-xet==1.1.3
+    # via
+    #   -r requirements/base.txt
+    #   huggingface-hub
+httpcore==1.0.9
     # via
     #   -r requirements/base.txt
     #   httpx
 httpx==0.28.1
     # via
     #   -r requirements/base.txt
-    #   litellm
     #   openai
-huggingface-hub==0.29.2
+huggingface-hub==0.33.0
     # via
     #   -r requirements/base.txt
     #   tokenizers
@@ -143,18 +146,18 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   litellm
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 jinja2==3.1.6
     # via
     #   -r requirements/base.txt
     #   cookiecutter
     #   litellm
-jiter==0.8.2
+jiter==0.10.0
     # via
     #   -r requirements/base.txt
     #   openai
@@ -163,30 +166,22 @@ jmespath==1.0.1
     #   -r requirements/base.txt
     #   boto3
     #   botocore
-jsonschema==4.23.0
-    # via
-    #   -r requirements/base.txt
-    #   litellm
-jsonschema-specifications==2024.10.1
-    # via
-    #   -r requirements/base.txt
-    #   jsonschema
 lazy==1.6
     # via
     #   -r requirements/base.txt
     #   xblock
-litellm==1.63.3
+litellm==0.14.0
     # via -r requirements/base.txt
-lxml[html-clean]==5.3.1
+lxml[html-clean]==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
     #   lxml-html-clean
     #   xblock
     #   xblock-sdk
-lxml-html-clean==0.4.1
+lxml-html-clean==0.4.2
     # via lxml
-mako==1.3.9
+mako==1.3.10
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -202,56 +197,59 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.2.0
     # via -r requirements/test.in
-multidict==6.1.0
+multidict==6.4.4
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-openai==1.65.5
+openai==1.86.0
     # via
     #   -r requirements/base.txt
     #   litellm
-openedx-django-pyfs==3.7.0
+openedx-django-pyfs==3.8.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   xblock
-packaging==24.2
+packaging==25.0
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
     #   pytest
 path==16.16.0
     # via edx-i18n-tools
-pluggy==1.5.0
-    # via pytest
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
 polib==1.2.0
     # via edx-i18n-tools
-propcache==0.3.0
+propcache==0.3.2
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-pydantic==2.10.6
+pydantic==2.11.7
     # via
     #   -r requirements/base.txt
-    #   litellm
     #   openai
-pydantic-core==2.27.2
+pydantic-core==2.33.2
     # via
     #   -r requirements/base.txt
     #   pydantic
 pygments==2.19.1
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pypng==0.20220715.0
     # via xblock-sdk
-pytest==8.3.5
+pytest==8.4.0
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements/test.in
-pytest-django==4.10.0
+pytest-django==4.11.1
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
@@ -259,13 +257,13 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
     #   xblock
-python-dotenv==1.0.1
+python-dotenv==1.1.0
     # via
     #   -r requirements/base.txt
     #   litellm
 python-slugify==8.0.4
     # via cookiecutter
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -276,30 +274,20 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   huggingface-hub
     #   xblock
-referencing==0.36.2
-    # via
-    #   -r requirements/base.txt
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2024.11.6
     # via
     #   -r requirements/base.txt
     #   tiktoken
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements/base.txt
     #   cookiecutter
     #   huggingface-hub
     #   tiktoken
     #   xblock-sdk
-rich==13.9.4
+rich==14.0.0
     # via cookiecutter
-rpds-py==0.23.1
-    # via
-    #   -r requirements/base.txt
-    #   jsonschema
-    #   referencing
-s3transfer==0.11.4
+s3transfer==0.13.0
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -329,7 +317,7 @@ tiktoken==0.9.0
     # via
     #   -r requirements/base.txt
     #   litellm
-tokenizers==0.21.0
+tokenizers==0.21.1
     # via
     #   -r requirements/base.txt
     #   litellm
@@ -338,9 +326,9 @@ tqdm==4.67.1
     #   -r requirements/base.txt
     #   huggingface-hub
     #   openai
-types-python-dateutil==2.9.0.20241206
+types-python-dateutil==2.9.0.20250516
     # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -r requirements/base.txt
     #   anyio
@@ -348,14 +336,18 @@ typing-extensions==4.12.2
     #   openai
     #   pydantic
     #   pydantic-core
-    #   referencing
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   pydantic
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   botocore
     #   requests
-web-fragments==2.2.0
+web-fragments==3.1.0
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -365,17 +357,17 @@ webob==1.8.9
     #   -r requirements/base.txt
     #   xblock
     #   xblock-sdk
-xblock[django]==5.1.2
+xblock[django]==5.2.0
     # via
     #   -r requirements/base.txt
     #   xblock-sdk
-xblock-sdk==0.12.0
+xblock-sdk==0.13.0
     # via -r requirements/test.in
-yarl==1.18.3
+yarl==1.20.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
-zipp==3.21.0
+zipp==3.23.0
     # via
     #   -r requirements/base.txt
     #   importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,11 +8,12 @@ aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   -r requirements/base.txt
     #   litellm
-aiosignal==1.3.2
+    #   openai
+aiosignal==1.4.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -20,11 +21,6 @@ annotated-types==0.7.0
     # via
     #   -r requirements/base.txt
     #   pydantic
-anyio==4.9.0
-    # via
-    #   -r requirements/base.txt
-    #   httpx
-    #   openai
 appdirs==1.4.4
     # via
     #   -r requirements/base.txt
@@ -32,7 +28,7 @@ appdirs==1.4.4
     #   litellm
 arrow==1.3.0
     # via cookiecutter
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -42,11 +38,11 @@ attrs==25.3.0
     #   aiohttp
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.38.36
+boto3==1.40.0
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.38.36
+botocore==1.40.0
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -54,8 +50,6 @@ botocore==1.38.36
 certifi==2023.11.17
     # via
     #   -r requirements/base.txt
-    #   httpcore
-    #   httpx
     #   litellm
     #   requests
 chardet==5.2.0
@@ -71,16 +65,13 @@ click==8.2.1
     #   litellm
 cookiecutter==2.6.0
     # via xblock-sdk
-coverage[toml]==7.9.1
+coverage[toml]==7.10.1
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
-distro==1.9.0
+django==4.2.23
     # via
-    #   -r requirements/base.txt
-    #   openai
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https:/raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   django-appconf
     #   django-statici18n
@@ -115,35 +106,21 @@ fs-s3fs==1.1.1
     #   -r requirements/base.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
-h11==0.16.0
-    # via
-    #   -r requirements/base.txt
-    #   httpcore
-hf-xet==1.1.3
+hf-xet==1.1.5
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
-httpcore==1.0.9
-    # via
-    #   -r requirements/base.txt
-    #   httpx
-httpx==0.28.1
-    # via
-    #   -r requirements/base.txt
-    #   openai
-huggingface-hub==0.33.0
+huggingface-hub==0.34.3
     # via
     #   -r requirements/base.txt
     #   tokenizers
 idna==3.10
     # via
     #   -r requirements/base.txt
-    #   anyio
-    #   httpx
     #   requests
     #   yarl
 importlib-metadata==8.7.0
@@ -157,10 +134,6 @@ jinja2==3.1.6
     #   -r requirements/base.txt
     #   cookiecutter
     #   litellm
-jiter==0.10.0
-    # via
-    #   -r requirements/base.txt
-    #   openai
 jmespath==1.0.1
     # via
     #   -r requirements/base.txt
@@ -172,7 +145,7 @@ lazy==1.6
     #   xblock
 litellm==0.14.0
     # via -r requirements/base.txt
-lxml[html-clean]==5.4.0
+lxml[html-clean]==6.0.0
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
@@ -197,12 +170,12 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.2.0
     # via -r requirements/test.in
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-openai==1.86.0
+openai==0.28.1
     # via
     #   -r requirements/base.txt
     #   litellm
@@ -230,20 +203,18 @@ propcache==0.3.2
     #   aiohttp
     #   yarl
 pydantic==2.11.7
-    # via
-    #   -r requirements/base.txt
-    #   openai
+    # via -r requirements/base.txt
 pydantic-core==2.33.2
     # via
     #   -r requirements/base.txt
     #   pydantic
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   pytest
     #   rich
 pypng==0.20220715.0
     # via xblock-sdk
-pytest==8.4.0
+pytest==8.4.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -257,7 +228,7 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
     #   xblock
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via
     #   -r requirements/base.txt
     #   litellm
@@ -274,7 +245,7 @@ pyyaml==6.0.2
     #   edx-i18n-tools
     #   huggingface-hub
     #   xblock
-regex==2024.11.6
+regex==2025.7.34
     # via
     #   -r requirements/base.txt
     #   tiktoken
@@ -283,11 +254,12 @@ requests==2.32.4
     #   -r requirements/base.txt
     #   cookiecutter
     #   huggingface-hub
+    #   openai
     #   tiktoken
     #   xblock-sdk
-rich==14.0.0
+rich==14.1.0
     # via cookiecutter
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -302,11 +274,6 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/base.txt
-    #   anyio
-    #   openai
 sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
@@ -317,7 +284,7 @@ tiktoken==0.9.0
     # via
     #   -r requirements/base.txt
     #   litellm
-tokenizers==0.21.1
+tokenizers==0.21.4
     # via
     #   -r requirements/base.txt
     #   litellm
@@ -326,14 +293,13 @@ tqdm==4.67.1
     #   -r requirements/base.txt
     #   huggingface-hub
     #   openai
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250708
     # via arrow
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/base.txt
-    #   anyio
+    #   aiosignal
     #   huggingface-hub
-    #   openai
     #   pydantic
     #   pydantic-core
     #   typing-inspection
@@ -341,9 +307,8 @@ typing-inspection==0.4.1
     # via
     #   -r requirements/base.txt
     #   pydantic
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   botocore
     #   requests

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     install_requires=[
         "XBlock",
-        "litellm>=1.42",
+        "litellm>=0.14,<1.0",
     ],
     entry_points={
         "xblock.v1": [


### PR DESCRIPTION
## Description

This PR adds the option to route all LLM calls through a user‑provided “custom” LLM service instead of the default provider. The option can be enabled via a feature flag named `USE_CUSTOM_LLM_SERVICE` that can be passed in through the site configuration, along with the custom service's endpoints. And the Oauth2 client credentials through Django settings.

## Supporting information

Opencraft Internal Jira task: [BB-9550](https://tasks.opencraft.com/browse/BB-9550)

## Testing instructions

1. Deploy this branch of the XBlock.
2. Enable custom service in Site Configuration. In your Open edX Django admin → Site Configurations, add:
```
           {
             "ai_eval": {
               "USE_CUSTOM_LLM_SERVICE": true,
               "CUSTOM_LLM_MODELS_URL": "https://your-custom-service/models",
               "CUSTOM_LLM_COMPLETIONS_URL": "https://your-custom-service/completions",
               "CUSTOM_LLM_TOKEN_URL": "https://your-custom-service/oauth/token"
             }
           }
```
3. Set the following client credentials in Django settings for Oauth2 (e.g. via Tutor’s configuration):
```
CUSTOM_LLM_CLIENT_ID = "your-client-id"
CUSTOM_LLM_CLIENT_SECRET = "your-client-secret"
```
4. Test the XBlock.

## Other information

Currently there's a version conflict that prevents this XBlock from being installed properly. The conflict is from the main edx-platform and documented in this [issue](https://github.com/openedx/edx-platform/issues/35268). Until that is resolved, a simple workaround could be to create a tutor plugin with the following content:
```
name: litellm-override
version: 0.1.0                                                                                                                                                                                                                                                                                                                                                                                                                                              

patches:
    openedx-dockerfile-post-python-requirements: |
        RUN pip install --no-cache-dir certifi==2023.11.17 && \
        pip install --no-cache-dir litellm==0.14.0 --no-deps
    openedx-dev-dockerfile-post-python-requirements: |
        RUN pip install --no-cache-dir certifi==2023.11.17 && \
        pip install --no-cache-dir litellm==0.14.0 --no-deps    
```