### PR TITLE
Support for custom or self hosted Judge0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,51 @@ CUSTOM_LLM_CLIENT_SECRET = "your-client-secret"
 Your custom service must implement the expected OAuth2 client‑credentials flow and provide JSON endpoints
 for listing models, obtaining completions, and fetching tokens as used by `CustomLLMService`.
 
+### Custom Judge0 Service (advanced)
+
+The Short Answer with AI Evaluation can be configured to use a custom Judge0 service (self-hosted or a different provider).
+
+To enable a custom service, configure the following **Site Configuration** keys under the `ai_eval` namespace:
+
+```json
+{
+  "ai_eval": {
+    "JUDGE0_BASE_URL": "https://your-custom-service",
+    "SUPPORTED_LANGUAGES": {
+      "Python": {
+        "monaco_id": "python",
+        "judge0_id": 71
+      },
+      "JavaScript": {
+        "monaco_id": "javascript",
+        "judge0_id": 63
+      },
+      "Java": {
+        "monaco_id": "java",
+        "judge0_id": 62
+      },
+      "C++": {
+        "monaco_id": "cpp",
+        "judge0_id": 76
+      },
+      "HTML/CSS": {
+        "monaco_id": "html",
+        "judge0_id": 1
+      }
+    }
+  }
+}
+```
+
+**Note:** You can get the specific judge0_ids for your installation by calling the `/languages` endpoint. Get the monaco_id from monaco documentation.
+
+Additionally, set your client credentials in Django settings (e.g. via Tutor config):
+
+```python
+JUDGE0_API_KEY = "your-api-key"
+```
+
+
 ## Dependencies
 - [Judge0 API](https://judge0.com/)
 - [Monaco editor](https://github.com/microsoft/monaco-editor)

--- a/ai_eval/coding_ai_eval.py
+++ b/ai_eval/coding_ai_eval.py
@@ -1,4 +1,5 @@
 """Coding Xblock with AI evaluation."""
+from typing import Self
 
 import logging
 import pkg_resources
@@ -15,7 +16,7 @@ from .llm_services import TIMEOUT_ERROR_MESSAGE
 from .utils import (
     submit_code,
     get_submission_result,
-    SUPPORTED_LANGUAGE_MAP,
+    get_supported_language_map,
     LanguageLabels,
 )
 
@@ -55,7 +56,7 @@ class CodingAIEvalXBlock(AIEvalXBlock):
         help=_("The programming language used for this Xblock."),
         values=[
             {"display_name": language, "value": language}
-            for language in SUPPORTED_LANGUAGE_MAP
+            for language in get_supported_language_map()
         ],
         default=LanguageLabels.Python,
         Scope=Scope.settings,
@@ -102,6 +103,11 @@ class CodingAIEvalXBlock(AIEvalXBlock):
         data = pkg_resources.resource_string(__name__, path)
         return data.decode("utf8")
 
+    def get_judge0_api_key(self, obj: Self = None) -> str | None:
+        """Get the API key for Judge0."""
+
+        return self._get_model_config_value("judge0_api_key", obj)
+
     def student_view(self, context=None):
         """
         The primary view of the CodingAIEvalXBlock, shown to students
@@ -120,10 +126,11 @@ class CodingAIEvalXBlock(AIEvalXBlock):
 
         frag.add_javascript(self.resource_string("static/js/src/coding_ai_eval.js"))
 
+        language_map = get_supported_language_map()
         monaco_html = self.loader.render_django_template(
             "/templates/monaco.html",
             {
-                "monaco_language": SUPPORTED_LANGUAGE_MAP[self.language].monaco_id,
+                "monaco_language": language_map[self.language].monaco_id,
             },
         )
         marked_html = self.resource_string("static/html/marked-iframe.html")
@@ -168,7 +175,7 @@ class CodingAIEvalXBlock(AIEvalXBlock):
                 )
             )
 
-        if data.language != LanguageLabels.HTML_CSS and not data.judge0_api_key:
+        if data.language != LanguageLabels.HTML_CSS and not self.get_judge0_api_key(data):
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR, _("Judge0 API key is mandatory")
@@ -246,7 +253,7 @@ class CodingAIEvalXBlock(AIEvalXBlock):
         Submit code to Judge0.
         """
         submission_id = submit_code(
-            self.judge0_api_key, data["user_code"], self.language
+            self.get_judge0_api_key(), data["user_code"], self.language
         )
         return {"submission_id": submission_id}
 
@@ -266,7 +273,7 @@ class CodingAIEvalXBlock(AIEvalXBlock):
         Get code submission result.
         """
         submission_id = data["submission_id"]
-        return get_submission_result(self.judge0_api_key, submission_id)
+        return get_submission_result(self.get_judge0_api_key(), submission_id)
 
     @staticmethod
     def workbench_scenarios():

--- a/ai_eval/coding_ai_eval.py
+++ b/ai_eval/coding_ai_eval.py
@@ -5,6 +5,7 @@ import logging
 import pkg_resources
 
 from django.utils.translation import gettext_noop as _
+from django.conf import settings
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
@@ -106,7 +107,9 @@ class CodingAIEvalXBlock(AIEvalXBlock):
     def get_judge0_api_key(self, obj: Self = None) -> str | None:
         """Get the API key for Judge0."""
 
-        return self._get_model_config_value("judge0_api_key", obj)
+        obj = obj or self
+        api_key_from_settings = settings.JUDGE0_API_KEY if hasattr(settings, "JUDGE0_API_KEY") else None
+        return obj.judge0_api_key or api_key_from_settings
 
     def student_view(self, context=None):
         """

--- a/ai_eval/utils.py
+++ b/ai_eval/utils.py
@@ -29,16 +29,16 @@ class LanguageLabels:
 # https://ce.judge0.com/#statuses-and-languages-active-and-archived-languages
 SUPPORTED_LANGUAGE_MAP = {
     LanguageLabels.Python: ProgrammimgLanguage(
-        monaco_id="python", judge0_id=71
+        monaco_id="python", judge0_id=92
     ),  # Python (3.11.2)
     LanguageLabels.JavaScript: ProgrammimgLanguage(
-        monaco_id="javascript", judge0_id=63
+        monaco_id="javascript", judge0_id=93
     ),  # JavaScript (Node.js 18.15.0)
     LanguageLabels.Java: ProgrammimgLanguage(
-        monaco_id="java", judge0_id=62
+        monaco_id="java", judge0_id=91
     ),  # Java (JDK 17.0.6)
     LanguageLabels.CPP: ProgrammimgLanguage(
-        monaco_id="cpp", judge0_id=76
+        monaco_id="cpp", judge0_id=54
     ),  # C++ (GCC 9.2.0)
     # Monaco's HTML support includes CSS support within the 'style' tag.
     LanguageLabels.HTML_CSS: ProgrammimgLanguage(

--- a/ai_eval/utils.py
+++ b/ai_eval/utils.py
@@ -4,6 +4,7 @@ Utilities
 
 from dataclasses import dataclass
 import requests
+from .compat import get_site_configuration_value
 
 
 @dataclass
@@ -28,16 +29,16 @@ class LanguageLabels:
 # https://ce.judge0.com/#statuses-and-languages-active-and-archived-languages
 SUPPORTED_LANGUAGE_MAP = {
     LanguageLabels.Python: ProgrammimgLanguage(
-        monaco_id="python", judge0_id=92
+        monaco_id="python", judge0_id=71
     ),  # Python (3.11.2)
     LanguageLabels.JavaScript: ProgrammimgLanguage(
-        monaco_id="javascript", judge0_id=93
+        monaco_id="javascript", judge0_id=63
     ),  # JavaScript (Node.js 18.15.0)
     LanguageLabels.Java: ProgrammimgLanguage(
-        monaco_id="java", judge0_id=91
+        monaco_id="java", judge0_id=62
     ),  # Java (JDK 17.0.6)
     LanguageLabels.CPP: ProgrammimgLanguage(
-        monaco_id="cpp", judge0_id=54
+        monaco_id="cpp", judge0_id=76
     ),  # C++ (GCC 9.2.0)
     # Monaco's HTML support includes CSS support within the 'style' tag.
     LanguageLabels.HTML_CSS: ProgrammimgLanguage(
@@ -49,16 +50,48 @@ SUPPORTED_LANGUAGE_MAP = {
 JUDGE0_BASE_CE_URL = "https://judge0-ce.p.rapidapi.com"
 
 
+def _get_judge0_base_url() -> str:
+    """
+    Get the base URL for Judge0 API from site configuration.
+    """
+    return get_site_configuration_value("ai_eval", "JUDGE0_BASE_URL") or JUDGE0_BASE_CE_URL
+
+
+def get_supported_language_map() -> dict[str, ProgrammimgLanguage]:
+    """
+    Get the mapping of supported programming languages to their IDs in Judge0 and Monaco.
+
+    Returns:
+        A dictionary mapping language labels to their corresponding ProgrammimgLanguage objects.
+    """
+
+    # Try to get the supported languages from site configuration
+    custom_languages = get_site_configuration_value("ai_eval", "SUPPORTED_LANGUAGES")
+    if custom_languages:
+        return {
+            lang: ProgrammimgLanguage(
+                monaco_id=lang_data["monaco_id"],
+                judge0_id=lang_data["judge0_id"]
+            )
+            for lang, lang_data in custom_languages.items()
+        }
+
+    # Fallback to the default supported languages
+    return SUPPORTED_LANGUAGE_MAP
+
+
 def submit_code(api_key: str, code: str, language: str) -> str:
     """
     Submit code to the judge0 API.
     """
-    url = f"{JUDGE0_BASE_CE_URL}/submissions?base64_encoded=false&wait=false"
+    base_url = _get_judge0_base_url()
+    url = f"{base_url}/submissions?base64_encoded=false&wait=false"
     headers = {"content-type": "application/json", "x-rapidapi-key": api_key}
 
+    supported_languages = get_supported_language_map()
     data = {
         "source_code": code,
-        "language_id": SUPPORTED_LANGUAGE_MAP[language].judge0_id,
+        "language_id": supported_languages[language].judge0_id,
     }
 
     response = requests.post(url, headers=headers, json=data, timeout=10)
@@ -73,8 +106,8 @@ def get_submission_result(api_key: str, submission_id: str):
     """
     Get result from Judge0 submission.
     """
-
-    url = f"{JUDGE0_BASE_CE_URL}/submissions/{submission_id}?base64_encoded=false&fields=*"
+    base_url = _get_judge0_base_url()
+    url = f"{base_url}/submissions/{submission_id}?base64_encoded=false&fields=*"
     headers = {"content-type": "application/json", "x-rapidapi-key": api_key}
 
     response = requests.get(url, headers=headers, timeout=10)


### PR DESCRIPTION
## Description

Implemented new configuration variables to allow setting a custom base URL for Judge0, and also configuring the supported lenguages. This is required because the language id's don't match between the self-hosted version of Judge0 vs the managed one.

## Supporting information

N/A

## Testing instructions

Two new site configuration variables were added:

- JUDGE0_BASE_URL
- SUPPORTED_LANGUAGES

Also, another variable was added which should be added via django settings:

- JUDGE0_API_KEY

All these variables are optional, if not set, it will use the old hardcoded values as default. JUDGE0_API_KEY can also be set from the XBlock configuration.

See updated readme for details.
