### PR TITLE
[BB-9988] Add option to use conversation_id for custom llm service

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ CUSTOM_LLM_CLIENT_SECRET = "your-client-secret"
 Your custom service must implement the expected OAuth2 client‑credentials flow and provide JSON endpoints
 for listing models, obtaining completions, and fetching tokens as used by `CustomLLMService`.
 
+#### Optional provider threads (conversation IDs)
+
+For deployments using a custom LLM service, you can enable provider‑side threads to cache context between turns. This is optional and disabled by default. When enabled, the LMS/XBlock remains the canonical chat history as that ensures vendor flexibility and continuity; provider threads are treated as a cache.
+
+- Site configuration (under `ai_eval`):
+  - `USE_PROVIDER_THREADS`: boolean, default `false`. When `true`, `CustomLLMService` attempts to reuse a provider conversation ID.
+- XBlock user state (managed automatically):
+  - `thread_id`: provider conversation ID cache.
+  - `thread_tag`: fingerprint of provider/model/prompt used to invalidate stale threads when configuration changes.
+
+Changing model or prompt automatically invalidates the cached thread; using the Reset button also clears both `thread_id` and `thread_tag`.
+
+Compatibility and fallback
+- Not all vendors/models support `conversation_id`. The default service path (via LiteLLM chat completions) does not use provider threads; calls remain stateless.
+- If threads are unsupported or ignored by a provider, the code still works and behaves statelessly.
+- With a custom provider that supports threads, the first turn sends full context and later turns send only the latest user input along with the cached `conversation_id`.
+
 ### Custom Code Execution Service (advanced)
 
 The Coding XBlock can route code execution to a third‑party service instead of Judge0. The service is expected to be asynchronous, exposing a submit endpoint that returns a submission identifier, and a results endpoint that returns the execution result when available. Configure this via Django settings:

--- a/README.md
+++ b/README.md
@@ -100,10 +100,9 @@ For deployments using a custom LLM service, you can enable provider‑side threa
 - Site configuration (under `ai_eval`):
   - `USE_PROVIDER_THREADS`: boolean, default `false`. When `true`, `CustomLLMService` attempts to reuse a provider conversation ID.
 - XBlock user state (managed automatically):
-  - `thread_id`: provider conversation ID cache.
-  - `thread_tag`: fingerprint of provider/model/prompt used to invalidate stale threads when configuration changes.
+  - `thread_map`: a dictionary mapping `tag -> conversation_id`, where `tag = provider:model:prompt_hash`. This allows multiple concurrent provider threads per learner per XBlock, one per distinct prompt/model context.
 
-Changing model or prompt automatically invalidates the cached thread; using the Reset button also clears both `thread_id` and `thread_tag`.
+Reset clears `thread_map`. If a provider ignores threads, behavior remains stateless.
 
 Compatibility and fallback
 - Not all vendors/models support `conversation_id`. The default service path (via LiteLLM chat completions) does not use provider threads; calls remain stateless.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ for listing models, obtaining completions, and fetching tokens as used by `Custo
 For deployments using a custom LLM service, you can enable provider‑side threads to cache context between turns. This is optional and disabled by default. When enabled, the LMS/XBlock remains the canonical chat history as that ensures vendor flexibility and continuity; provider threads are treated as a cache.
 
 - Site configuration (under `ai_eval`):
-  - `USE_PROVIDER_THREADS`: boolean, default `false`. When `true`, `CustomLLMService` attempts to reuse a provider conversation ID.
+  - `PROVIDER_SUPPORTS_THREADS`: boolean, default `false`. When `true`, `CustomLLMService` attempts to reuse a provider conversation ID.
 - XBlock user state (managed automatically):
   - `thread_map`: a dictionary mapping `tag -> conversation_id`, where `tag = provider:model:prompt_hash`. This allows multiple concurrent provider threads per learner per XBlock, one per distinct prompt/model context.
 

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -78,6 +78,16 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         default="",
         values_provider=_get_model_choices,
     )
+    thread_id = String(
+        help=_("Provider conversation/thread identifier (cache only)"),
+        default="",
+        scope=Scope.user_state,
+    )
+    thread_tag = String(
+        help=_("Fingerprint of provider/model/prompt for thread reuse"),
+        default="",
+        scope=Scope.user_state,
+    )
 
     editable_fields = (
         "display_name",
@@ -207,5 +217,17 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
                 )
 
     def get_llm_response(self, messages):
-        return get_llm_response(self.model, self.get_model_api_key(), messages,
-                                self.get_model_api_url())
+        """
+        Call the shared LLM entrypoint and return the response.
+        """
+        prior_thread_id = self.thread_id or None
+        text, new_thread_id = get_llm_response(
+            self.model,
+            self.get_model_api_key(),
+            messages,
+            self.get_model_api_url(),
+            thread_id=prior_thread_id,
+        )
+        if new_thread_id:
+            self.thread_id = new_thread_id
+        return text

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -6,7 +6,7 @@ import pkg_resources
 
 from django.utils.translation import gettext_noop as _
 from xblock.core import XBlock
-from xblock.fields import String, Scope
+from xblock.fields import String, Scope, Dict
 from xblock.utils.resources import ResourceLoader
 from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xblock.validation import ValidationMessage
@@ -78,14 +78,9 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         default="",
         values_provider=_get_model_choices,
     )
-    thread_id = String(
-        help=_("Provider conversation/thread identifier (cache only)"),
-        default="",
-        scope=Scope.user_state,
-    )
-    thread_tag = String(
-        help=_("Fingerprint of provider/model/prompt for thread reuse"),
-        default="",
+    thread_map = Dict(
+        help=_("Map of provider thread IDs keyed by tag"),
+        default={},
         scope=Scope.user_state,
     )
 
@@ -216,11 +211,17 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
                     )
                 )
 
-    def get_llm_response(self, messages):
+    def get_llm_response(self, messages, tag: str | None = None):
         """
-        Call the shared LLM entrypoint and return the response.
+        Call the shared LLM entrypoint and return only the response text.
         """
-        prior_thread_id = self.thread_id or None
+        prior_thread_id = None
+        if tag:
+            try:
+                prior_thread_id = (self.thread_map or {}).get(tag) or None
+            except Exception:  # pylint: disable=broad-exception-caught
+                prior_thread_id = None
+
         text, new_thread_id = get_llm_response(
             self.model,
             self.get_model_api_key(),
@@ -228,6 +229,8 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             self.get_model_api_url(),
             thread_id=prior_thread_id,
         )
-        if new_thread_id:
-            self.thread_id = new_thread_id
+        if tag and new_thread_id:
+            tm = dict(getattr(self, "thread_map", {}) or {})
+            tm[tag] = new_thread_id
+            self.thread_map = tm
         return text

--- a/ai_eval/llm.py
+++ b/ai_eval/llm.py
@@ -83,9 +83,19 @@ def get_llm_response(
         tuple[str, Optional[str]]: The response text and a new thread id if a provider thread was created/used.
     """
     llm_service = get_llm_service()
-    use_threads = False
+    allow_threads = False
     try:
-        use_threads = bool(llm_service.supports_threads())
+        allow_threads = bool(llm_service.supports_threads())
     except Exception:  # pylint: disable=broad-exception-caught
-        use_threads = False
-    return llm_service.get_response(model, api_key, messages, api_base, thread_id=thread_id, use_threads=use_threads)
+        allow_threads = False
+
+    # Continue threaded conversation when a thread_id is provided
+    if thread_id:
+        return llm_service.get_response(model, api_key, messages, api_base, thread_id=thread_id)
+
+    # Start a new thread only when allowed in config setting
+    if allow_threads:
+        return llm_service.start_thread(model, api_key, messages, api_base)
+
+    # Stateless call - do not create or persist any conversation id
+    return llm_service.get_response(model, api_key, messages, api_base, thread_id=None)

--- a/ai_eval/llm.py
+++ b/ai_eval/llm.py
@@ -50,8 +50,8 @@ def get_llm_service():
 
 
 def get_llm_response(
-    model: str, api_key: str, messages: list, api_base: str
-) -> str:
+    model: str, api_key: str, messages: list, api_base: str, thread_id: str | None = None
+) -> tuple[str, str | None]:
     """
     Get LLM response, using either the default or custom service based on site configuration.
 
@@ -80,8 +80,12 @@ def get_llm_response(
             API request URL. This is required only when using Llama which doesn't have an official provider.
 
     Returns:
-        str: The response text from the LLM. This is typically the generated output based on the provided
-            messages.
+        tuple[str, Optional[str]]: The response text and a new thread id if a provider thread was created/used.
     """
     llm_service = get_llm_service()
-    return llm_service.get_response(model, api_key, messages, api_base)
+    use_threads = False
+    try:
+        use_threads = bool(llm_service.supports_threads())
+    except Exception:  # pylint: disable=broad-exception-caught
+        use_threads = False
+    return llm_service.get_response(model, api_key, messages, api_base, thread_id=thread_id, use_threads=use_threads)

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -6,6 +6,7 @@ import requests
 
 from litellm import completion
 from .supported_models import SupportedModels
+from .compat import get_site_configuration_value
 
 logger = logging.getLogger(__name__)
 
@@ -16,29 +17,64 @@ class LLMServiceBase:
     """
     Base class for llm service.
     """
-    def get_response(self, model, api_key, messages, api_base):
+    # pylint: disable=too-many-positional-arguments
+    def get_response(self, model, api_key, messages, api_base, thread_id=None, use_threads=False):
+        """Get a response from the provider.
+
+        Args:
+            model (str): Model identifier.
+            api_key (str): API key (for default providers or passthrough).
+            messages (list[dict]): Chat messages.
+            api_base (str|None): Optional base URL (e.g., for llama/ollama).
+            thread_id (str|None): Optional provider-side conversation/thread id.
+            use_threads (bool): Whether provider threads are enabled by policy.
+
+        Returns:
+            tuple[str, str|None]: (response_text, new_thread_id)
+        """
         raise NotImplementedError
 
     def get_available_models(self):
         raise NotImplementedError
+
+    def supports_threads(self) -> bool:
+        """
+        Check if this service supports provider-side threads.
+
+        Default is False; custom services can override to be flag-driven.
+        """
+        return False
 
 
 class DefaultLLMService(LLMServiceBase):
     """
     Default llm service.
     """
-    def get_response(self, model, api_key, messages, api_base):
+    # pylint: disable=too-many-positional-arguments
+    def get_response(
+            self,
+            model,
+            api_key,
+            messages,
+            api_base,
+            thread_id=None,
+            use_threads=False
+    ):
         kwargs = {}
         if api_base:
             kwargs["api_base"] = api_base
-        return (
+        text = (
             completion(model=model, api_key=api_key, messages=messages, **kwargs)
             .choices[0]
             .message.content
         )
+        return text, None
 
     def get_available_models(self):
         return [str(m.value) for m in SupportedModels]
+
+    def supports_threads(self) -> bool:  # pragma: nocover - default is stateless
+        return False
 
 
 class CustomLLMService(LLMServiceBase):
@@ -81,25 +117,56 @@ class CustomLLMService(LLMServiceBase):
         self._ensure_token()
         return {'Authorization': f'Bearer {self._access_token}'}
 
-    def get_response(self, model, api_key, messages, api_base):
+    def get_response(
+            self,
+            model,
+            api_key,
+            messages,
+            api_base,
+            thread_id=None,
+            use_threads=False
+    ):
         """
         Send completion request to custom LLM endpoint.
         """
         url = self.completions_url
+        # When reusing an existing thread, only send the latest user input and rely on
+        # the provider to apply prior context associated with the conversation_id.
+        if use_threads and thread_id:
+            latest_user = None
+            for msg in reversed(messages):
+                if (msg.get('role') or '').lower() == 'user':
+                    latest_user = msg.get('content', '').strip()
+                    break
+            prompt = f"User: {latest_user}" if latest_user is not None else ""
+        else:
+            prompt = " ".join(
+                f"{msg.get('role', '').capitalize()}: {msg.get('content', '').strip()}"
+                for msg in messages
+            )
         # Adjust the payload structure based on custom API requirements
-        prompt = " ".join(
-            f"{msg.get('role', '').capitalize()}: {msg.get('content', '').strip()}"
-            for msg in messages
-        )
         payload = {
             "model": str(model),
             "prompt": prompt,
         }
+        # If threads are enabled, pass through conversation id when available
+        # and let the provider initialize a new thread if not.
+        if use_threads and thread_id:
+            payload["conversation_id"] = thread_id
+
         response = requests.post(url, json=payload, headers=self._get_headers(), timeout=10)
         response.raise_for_status()
         data = response.json()
         # Adjust this if custom API returns the response differently
-        return data.get("response")
+        text = data.get("response")
+        # Try to capture a new conversation/thread id if the API returns one.
+        new_thread_id = None
+        if use_threads:
+            new_thread_id = (
+                data.get("conversation_id")
+                or (data.get("data", {}) if isinstance(data.get("data"), dict) else {}).get("conversation_id")
+            )
+        return text, new_thread_id
 
     def get_available_models(self):
         url = self.models_url
@@ -153,3 +220,10 @@ class CustomLLMService(LLMServiceBase):
                 exc_info=True,
             )
             return []
+
+    def supports_threads(self) -> bool:
+        """Return whether provider threads should be used, from site flag."""
+        try:
+            return bool(get_site_configuration_value("ai_eval", "USE_PROVIDER_THREADS"))
+        except Exception:  # pylint: disable=broad-exception-caught
+            return False

--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -18,8 +18,9 @@ class LLMServiceBase:
     Base class for llm service.
     """
     # pylint: disable=too-many-positional-arguments
-    def get_response(self, model, api_key, messages, api_base, thread_id=None, use_threads=False):
-        """Get a response from the provider.
+    def get_response(self, model, api_key, messages, api_base, thread_id=None):
+        """
+        Get a response from the provider.
 
         Args:
             model (str): Model identifier.
@@ -27,7 +28,18 @@ class LLMServiceBase:
             messages (list[dict]): Chat messages.
             api_base (str|None): Optional base URL (e.g., for llama/ollama).
             thread_id (str|None): Optional provider-side conversation/thread id.
-            use_threads (bool): Whether provider threads are enabled by policy.
+
+        Returns:
+            tuple[str, str|None]: (response_text, optional_thread_id)
+        """
+        raise NotImplementedError
+
+    # pylint: disable=too-many-positional-arguments
+    def start_thread(self, model, api_key, messages, api_base):
+        """
+        Start a new provider-side thread and return its first response.
+
+        Return the provider-issued conversation/thread id if available.
 
         Returns:
             tuple[str, str|None]: (response_text, new_thread_id)
@@ -58,7 +70,6 @@ class DefaultLLMService(LLMServiceBase):
             messages,
             api_base,
             thread_id=None,
-            use_threads=False
     ):
         kwargs = {}
         if api_base:
@@ -69,6 +80,9 @@ class DefaultLLMService(LLMServiceBase):
             .message.content
         )
         return text, None
+
+    def start_thread(self, model, api_key, messages, api_base):  # pragma: no cover - trivial passthrough
+        return self.get_response(model, api_key, messages, api_base, thread_id=None)
 
     def get_available_models(self):
         return [str(m.value) for m in SupportedModels]
@@ -124,15 +138,16 @@ class CustomLLMService(LLMServiceBase):
             messages,
             api_base,
             thread_id=None,
-            use_threads=False
     ):
         """
         Send completion request to custom LLM endpoint.
+        If thread_id is provided, include it and send only the latest user input.
+        If thread_id is None, send full context and return (text, None).
         """
         url = self.completions_url
         # When reusing an existing thread, only send the latest user input and rely on
         # the provider to apply prior context associated with the conversation_id.
-        if use_threads and thread_id:
+        if thread_id:
             latest_user = None
             for msg in reversed(messages):
                 if (msg.get('role') or '').lower() == 'user':
@@ -149,9 +164,8 @@ class CustomLLMService(LLMServiceBase):
             "model": str(model),
             "prompt": prompt,
         }
-        # If threads are enabled, pass through conversation id when available
-        # and let the provider initialize a new thread if not.
-        if use_threads and thread_id:
+
+        if thread_id:
             payload["conversation_id"] = thread_id
 
         response = requests.post(url, json=payload, headers=self._get_headers(), timeout=10)
@@ -159,13 +173,34 @@ class CustomLLMService(LLMServiceBase):
         data = response.json()
         # Adjust this if custom API returns the response differently
         text = data.get("response")
-        # Try to capture a new conversation/thread id if the API returns one.
-        new_thread_id = None
-        if use_threads:
-            new_thread_id = (
-                data.get("conversation_id")
-                or (data.get("data", {}) if isinstance(data.get("data"), dict) else {}).get("conversation_id")
-            )
+
+        if thread_id:
+            new_thread_id = data.get("conversation_id")
+            if not new_thread_id and isinstance(data.get("data"), dict):
+                new_thread_id = data["data"].get("conversation_id")
+            return text, new_thread_id
+        return text, None
+
+    def start_thread(self, model, api_key, messages, api_base):
+        """
+        Start new thread.
+        """
+        url = self.completions_url
+        prompt = " ".join(
+            f"{msg.get('role', '').capitalize()}: {msg.get('content', '').strip()}"
+            for msg in messages
+        )
+        payload = {
+            "model": str(model),
+            "prompt": prompt,
+        }
+        response = requests.post(url, json=payload, headers=self._get_headers(), timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        text = data.get("response")
+        new_thread_id = data.get("conversation_id")
+        if not new_thread_id and isinstance(data.get("data"), dict):
+            new_thread_id = data["data"].get("conversation_id")
         return text, new_thread_id
 
     def get_available_models(self):
@@ -224,6 +259,7 @@ class CustomLLMService(LLMServiceBase):
     def supports_threads(self) -> bool:
         """Return whether provider threads should be used, from site flag."""
         try:
-            return bool(get_site_configuration_value("ai_eval", "USE_PROVIDER_THREADS"))
+            val = get_site_configuration_value("ai_eval", "PROVIDER_SUPPORTS_THREADS")
+            return bool(val)
         except Exception:  # pylint: disable=broad-exception-caught
             return False

--- a/ai_eval/shortanswer.py
+++ b/ai_eval/shortanswer.py
@@ -207,9 +207,6 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         llm_service = get_llm_service()
         provider_tag = "custom" if isinstance(llm_service, CustomLLMService) else "default"
         current_tag = f"{provider_tag}:{self.model}:{prompt_hash}"
-        # Invalidate stale threads when tag changes
-        if getattr(self, "thread_tag", "") != current_tag:
-            self.thread_id = ""
 
         system_msg = {
             "role": "system",
@@ -234,8 +231,7 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         messages.append({"role": "user", "content": user_submission})
 
         try:
-            # Use the base wrapper which will pass/persist thread_id when supported
-            response = self.get_llm_response(messages)
+            text = self.get_llm_response(messages, tag=current_tag)
         except Exception as e:
             logger.error(
                 f"Failed while making LLM request using model {self.model}. Error: {e}",
@@ -243,13 +239,10 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
             )
             raise JsonHandlerError(500, "A probem occured. Please retry.") from e
 
-        if response:
+        if text:
             self.messages[self.USER_KEY].append(user_submission)
-            self.messages[self.LLM_KEY].append(response)
-            # Persist the tag when a provider thread is active
-            if getattr(self, "thread_id", ""):
-                self.thread_tag = current_tag
-            return {"response": response}
+            self.messages[self.LLM_KEY].append(text)
+            return {"response": text}
 
         raise JsonHandlerError(500, "A probem occured. The LLM sent an empty response.")
 
@@ -261,8 +254,7 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         if not self.allow_reset:
             raise JsonHandlerError(403, "Reset is disabled.")
         self.messages = {self.USER_KEY: [], self.LLM_KEY: []}
-        self.thread_id = ""
-        self.thread_tag = ""
+        self.thread_map = {}
         return {}
 
     @staticmethod

--- a/ai_eval/shortanswer.py
+++ b/ai_eval/shortanswer.py
@@ -1,6 +1,7 @@
 """Short answers Xblock with AI evaluation."""
 
 import logging
+import hashlib
 import urllib.parse
 import urllib.request
 from multiprocessing.dummy import Pool
@@ -14,6 +15,8 @@ from xblock.fields import Boolean, Dict, Integer, List, String, Scope
 from xblock.validation import ValidationMessage
 
 from .base import AIEvalXBlock
+from .llm import get_llm_service
+from .llm_services import CustomLLMService
 
 
 logger = logging.getLogger(__name__)
@@ -178,14 +181,35 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         user_submission = str(data["user_input"])
 
         attachments = []
+        attachment_hash_inputs = []
         for filename, contents in self._get_attachments():
+            # Build system prompt attachment section (HTML-like) as before
             attachments.append(f"""
                 <attachment>
                     <filename>{saxutils.escape(filename)}</filename>
                     <contents>{saxutils.escape(contents)}</contents>
                 </attachment>
             """)
+            # For tagging, hash filename + contents
+            attachment_hash_inputs.append(f"{filename}|{contents}")
         attachments = '\n'.join(attachments)
+
+        # Compute a tag to identify compatible reuse across provider/model/prompt
+        # Include evaluation prompt, question, and attachment content hashes
+        prompt_hasher = hashlib.sha256()
+        prompt_hasher.update((self.evaluation_prompt or "").strip().encode("utf-8"))
+        prompt_hasher.update((self.question or "").strip().encode("utf-8"))
+        for item in attachment_hash_inputs:
+            prompt_hasher.update(item.encode("utf-8"))
+        prompt_hash = prompt_hasher.hexdigest()
+
+        # Determine provider tag based on service type
+        llm_service = get_llm_service()
+        provider_tag = "custom" if isinstance(llm_service, CustomLLMService) else "default"
+        current_tag = f"{provider_tag}:{self.model}:{prompt_hash}"
+        # Invalidate stale threads when tag changes
+        if getattr(self, "thread_tag", "") != current_tag:
+            self.thread_id = ""
 
         system_msg = {
             "role": "system",
@@ -210,6 +234,7 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         messages.append({"role": "user", "content": user_submission})
 
         try:
+            # Use the base wrapper which will pass/persist thread_id when supported
             response = self.get_llm_response(messages)
         except Exception as e:
             logger.error(
@@ -221,6 +246,9 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         if response:
             self.messages[self.USER_KEY].append(user_submission)
             self.messages[self.LLM_KEY].append(response)
+            # Persist the tag when a provider thread is active
+            if getattr(self, "thread_id", ""):
+                self.thread_tag = current_tag
             return {"response": response}
 
         raise JsonHandlerError(500, "A probem occured. The LLM sent an empty response.")
@@ -233,6 +261,8 @@ class ShortAnswerAIEvalXBlock(AIEvalXBlock):
         if not self.allow_reset:
             raise JsonHandlerError(403, "Reset is disabled.")
         self.messages = {self.USER_KEY: [], self.LLM_KEY: []}
+        self.thread_id = ""
+        self.thread_tag = ""
         return {}
 
     @staticmethod

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -102,13 +102,11 @@ def test_shortanswer_reset_allowed(shortanswer_block_data):
         "messages": {"USER": ["Hello"], "LLM": ["Hello"]},
     }
     block = ShortAnswerAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
-    # Pre-populate thread metadata to verify reset clears it
-    block.thread_id = "abc123"
-    block.thread_tag = "provider:model:tag"
+    # Pre-populate thread map to verify reset clears it
+    block.thread_map = {"provider:model:tag": "abc123"}
     block.reset.__wrapped__(block, data={})
     assert block.messages == {"USER": [], "LLM": []}
-    assert block.thread_id == ""
-    assert block.thread_tag == ""
+    assert not block.thread_map
 
 
 def test_shortanswer_reset_forbidden(shortanswer_block_data):

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -145,7 +145,13 @@ def test_shortanswer_attachments(shortanswer_block_data):
     }
     block = ShortAnswerAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
     block._download_attachment = Mock(return_value="file contents <&>")
-    with patch('ai_eval.llm.get_llm_response') as mocked:
+    with patch('ai_eval.shortanswer.get_llm_service') as mock_service, \
+         patch('ai_eval.llm.get_llm_service') as mock_llm_service, \
+         patch('ai_eval.base.get_site_configuration_value', return_value=None), \
+         patch('ai_eval.base.get_llm_response') as mocked:
+        mock_service.return_value = Mock()
+        mock_service.return_value.supports_threads.return_value = False
+        mock_llm_service.return_value = mock_service.return_value
         mocked.return_value = (".", None)
         block.get_response.__wrapped__(block, data={"user_input": "."})
         # Extract the messages argument passed into get_llm_response

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -102,8 +102,13 @@ def test_shortanswer_reset_allowed(shortanswer_block_data):
         "messages": {"USER": ["Hello"], "LLM": ["Hello"]},
     }
     block = ShortAnswerAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
+    # Pre-populate thread metadata to verify reset clears it
+    block.thread_id = "abc123"
+    block.thread_tag = "provider:model:tag"
     block.reset.__wrapped__(block, data={})
     assert block.messages == {"USER": [], "LLM": []}
+    assert block.thread_id == ""
+    assert block.thread_tag == ""
 
 
 def test_shortanswer_reset_forbidden(shortanswer_block_data):
@@ -140,9 +145,11 @@ def test_shortanswer_attachments(shortanswer_block_data):
     }
     block = ShortAnswerAIEvalXBlock(ToyRuntime(), DictFieldData(data), None)
     block._download_attachment = Mock(return_value="file contents <&>")
-    block.get_llm_response = Mock(return_value=".")
-    block.get_response.__wrapped__(block, data={"user_input": "."})
-    messages = block.get_llm_response.call_args.args[0]
+    with patch('ai_eval.llm.get_llm_response') as mocked:
+        mocked.return_value = (".", None)
+        block.get_response.__wrapped__(block, data={"user_input": "."})
+        # Extract the messages argument passed into get_llm_response
+        messages = mocked.call_args.kwargs.get('messages') or mocked.call_args.args[2]
     prompt = messages[0]["content"]
     assert "<filename>1.txt</filename>" in prompt
     assert "<contents>file contents &lt;&amp;&gt;</contents>" in prompt


### PR DESCRIPTION
## Description

This PR adds optional provider‑side threads (conversation IDs) for custom LLM services, gated by the `USE_PROVIDER_THREADS` site flag. The XBlock caches a provider `thread_id` and tracks a `thread_tag`
fingerprint (provider/model/prompt/attachments) to auto‑invalidate when settings change; Reset clears both. The shared LLM wrapper passes and persists thread IDs when supported, while the default path remains stateless.
 
Important note: The XBlock/LMS remains the canonical chat history (source of truth) so that we can preserve vendor flexibility, continuity, and deterministic behavior; provider threads are treated only as a cache and we safely fall back when unsupported.

This update affects only chat interactions; the Coding XBlock and its code‑execution flow are not impacted as they are one-time feedback only (stateless).

## Supporting information

OpenCraft Internal Jira task: [BB-9988](https://tasks.opencraft.com/browse/BB-9988)

## Screenshot

<img width="1364" height="379" alt="Screenshot 2025-09-04 at 2 00 48 PM" src="https://github.com/user-attachments/assets/5d2a0f71-3b84-4fad-abf2-552be99b32ba" />


## Testing instructions

1. Deploy this branch of the XBlock.
2. Without making any config changes, verify that the default path (with the standard providers and models) is working as expected.
3. Configure a custom LLM service through the site config, make sure to include the new `USE_PROVIDER_THREADS` flag set to True.
4. Test the AI XBlocks; Both chat and coding xblocks should work without trouble.
5. To verify that the conversation_id is set correctly and used, go to django admin and check `/admin/courseware/studentmodule/` to see that the user states have a conversation_id set.

## Other information

This depends on  #14 as that contains a bunch of important code refactoring. Once #14 is merged, this will need to be rebased before merging.
