### PR TITLE
[BB-10439] Update AI Export Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ## Introduction
 
-This repository hosts two Open edX XBlocks: 
+This repository hosts several Open edX XBlocks, including:
 
 1. **Short Answer with AI Evaluation**: This XBlock allows students to submit short answers, which are then evaluated with the help of a large language model (LLM).
 2. **Coding with AI Evaluation**: This XBlock allows students to submit code in a text editor. The code is executed via a third-party API (currently using [Judge0](https://judge0.com/)), and both the code and its output are sent to an LLM for feedback.
+3. **AI Eval Export (staff tool)**: This XBlock allows course staff to export learner conversations/sessions from supported AI Eval XBlocks as a CSV.
 
 ## Screeshots
 
@@ -26,11 +27,20 @@ This repository hosts two Open edX XBlocks:
 
 2. Launch Tutor.
 
-3. In the Open edX platform, navigate to `Settings > Advanced Settings` and add `shortanswer_ai_eval` and `coding_ai_eval` to the `Advanced Module List`.
+3. In the Open edX platform, navigate to `Settings > Advanced Settings` and add `shortanswer_ai_eval` and `coding_ai_eval` to the `Advanced Module List`. If you want the export tool, also add `ai_eval_export`.
 
 4. Add either XBlock using the `Advanced` button in the `Add New Component` section of Studio.
 
 5. Configure the added Xblock and make sure to add correct API keys. You can format your question and prompts using [Markdown](https://marked.js.org/demo/).
+
+### Export Tool (ai_eval_export)
+
+The `ai_eval_export` XBlock is a preconfigured, staff-only tool for exporting learner conversation/session history from supported AI Eval XBlocks in a course.
+
+- Enable it by adding `ai_eval_export` to the course `Advanced Module List`, then add it to a unit via the Studio “Advanced” component picker.
+- It only works from the LMS (Studio/CMS uses different Celery queues), and it only renders for course staff.
+- Clicking “Start export” generates a CSV and provides a download link when ready.
+- The CSV includes a `Course Name` column (human-readable course title) and includes `Location` to identify the specific XBlock usage within the course.
 
 ### API Configuration
 

--- a/ai_eval/tasks.py
+++ b/ai_eval/tasks.py
@@ -20,11 +20,70 @@ logger = get_task_logger(__name__)
 
 User = get_user_model()
 
+_BASE_HEADER = (
+    "Section",
+    "Subsection",
+    "Unit",
+    "Location",
+    "Display Name",
+    "Username",
+    "User E-mail",
+    "Conversation",
+    "Source",
+    "Message",
+)
+
 _BLOCK_CATEGORIES = [
     'coding_ai_eval',
     'multiagent_ai_eval',
     'shortanswer_ai_eval',
 ]
+
+
+def _get_course_display_name(course_id):
+    """
+    Return a human-readable course title for `course_id`.
+
+    Best-effort: on any error, fall back to `str(course_id)`.
+    """
+    for getter in (
+        _get_course_display_name_from_course_overview,
+        _get_course_display_name_from_modulestore,
+    ):
+        try:
+            display_name = getter(course_id)
+        except Exception:  # pylint: disable=broad-exception-caught
+            display_name = None
+        if display_name:
+            return str(display_name)
+    return str(course_id)
+
+
+def _get_course_display_name_from_course_overview(course_id):
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+    overview = CourseOverview.get_from_id(course_id)
+    return getattr(overview, "display_name", None)
+
+
+def _get_course_display_name_from_modulestore(course_id):
+    # pylint: disable=import-error,import-outside-toplevel
+    from xmodule.modulestore.django import modulestore
+
+    course = modulestore().get_course(course_id)
+    return getattr(course, "display_name", None) or getattr(
+        course, "display_name_with_default", None
+    )
+
+
+def _build_export_rows(course_display_name, data_rows_iter):
+    """
+    Build an export row iterator, prefixing each row with `course_display_name`.
+    """
+    header = ("Course Name",) + _BASE_HEADER
+    prefixed_data_rows = ((course_display_name,) + row for row in data_rows_iter)
+    return itertools.chain([header], prefixed_data_rows)
 
 
 @shared_task()
@@ -40,14 +99,11 @@ def export_data(course_id_str):
     start_timestamp = time.time()
 
     course_id = CourseKey.from_string(course_id_str)
+    course_display_name = _get_course_display_name(course_id)
 
     logger.debug("Beginning data export")
 
-    header = ("Section", "Subsection", "Unit", "Location",
-              "Display Name", "Username", "User E-mail", "Conversation",
-              "Source", "Message")
-
-    rows = itertools.chain([header], _extract_all_data(course_id))
+    rows = _build_export_rows(course_display_name, _extract_all_data(course_id))
 
     report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
 

--- a/ai_eval/tasks.py
+++ b/ai_eval/tasks.py
@@ -21,6 +21,7 @@ logger = get_task_logger(__name__)
 User = get_user_model()
 
 _BASE_HEADER = (
+    "Course Name",
     "Section",
     "Subsection",
     "Unit",
@@ -87,7 +88,7 @@ def _build_export_rows(course_display_name, data_rows_iter):
     """
     Build an export row iterator, prefixing each row with `course_display_name`.
     """
-    header = ("Course Name",) + _BASE_HEADER
+    header = _BASE_HEADER
     prefixed_data_rows = ((course_display_name,) + row for row in data_rows_iter)
     return itertools.chain([header], prefixed_data_rows)
 
@@ -186,12 +187,8 @@ def _iter_coach_messages(block, workspace_history, coach_history, evaluation_fra
 
     Ordering is best-effort: workspace first, then coach, then evaluation fragments.
     """
-    main_role = getattr(block, "character_1_role", None) or getattr(
-        block, "character_1_name", None
-    ) or "Main character"
-    coach_role = getattr(block, "character_2_role", None) or getattr(
-        block, "character_2_name", None
-    ) or "Coach"
+    main_role = block.character_1_role or "Main character"
+    coach_role = block.character_2_role or "Coach"
 
     def _iter_fragments(fragments, assistant_role):
         for fragment in fragments or []:
@@ -250,7 +247,7 @@ def _extract_data(block):
                     block.display_name,
                     user.username,
                     user.email or "",
-                    1,
+                    None,
                     source,
                     content,
                 )

--- a/ai_eval/tasks.py
+++ b/ai_eval/tasks.py
@@ -12,7 +12,7 @@ from xblock.fields import Scope
 from . import (
     coding_ai_eval,
     CodingAIEvalXBlock,
-    MultiAgentAIEvalXBlock,
+    CoachAIEvalXBlock,
     ShortAnswerAIEvalXBlock,
 )
 
@@ -35,7 +35,7 @@ _BASE_HEADER = (
 
 _BLOCK_CATEGORIES = [
     'coding_ai_eval',
-    'multiagent_ai_eval',
+    'coach_ai_eval',
     'shortanswer_ai_eval',
 ]
 
@@ -60,6 +60,9 @@ def _get_course_display_name(course_id):
 
 
 def _get_course_display_name_from_course_overview(course_id):
+    """
+    Get course name from course overview
+    """
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
@@ -68,6 +71,9 @@ def _get_course_display_name_from_course_overview(course_id):
 
 
 def _get_course_display_name_from_modulestore(course_id):
+    """
+    Get course name from modulestore
+    """
     # pylint: disable=import-error,import-outside-toplevel
     from xmodule.modulestore.django import modulestore
 
@@ -149,16 +155,61 @@ def _get_messages(block, session):
             if isinstance(block, ShortAnswerAIEvalXBlock):
                 source = message["source"]
                 content = message["content"]
-            elif isinstance(block, MultiAgentAIEvalXBlock):
-                source = message['role']
-                if 'extra' in message:
-                    source = (
-                        f"{source},{message['extra'].get('agent', '')}"
-                    )
-                content = message["content"]
             else:
                 continue
             yield (source, content)
+
+
+def _get_user_state_value(field_data_cache, block, user, field_name, default=None):
+    """
+    Fetch user state value for required field.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from lms.djangoapps.courseware.model_data import DjangoKeyValueStore
+
+    try:
+        return field_data_cache.get(
+            DjangoKeyValueStore.Key(
+                scope=Scope.user_state,
+                user_id=user.id,
+                block_scope_id=block.location,
+                field_name=field_name,
+            )
+        )
+    except KeyError:
+        return default
+
+
+def _iter_coach_messages(block, workspace_history, coach_history, evaluation_fragments):
+    """
+    Yield (source, content) tuples for CoachAIEvalXBlock user state.
+
+    Ordering is best-effort: workspace first, then coach, then evaluation fragments.
+    """
+    main_role = getattr(block, "character_1_role", None) or getattr(
+        block, "character_1_name", None
+    ) or "Main character"
+    coach_role = getattr(block, "character_2_role", None) or getattr(
+        block, "character_2_name", None
+    ) or "Coach"
+
+    def _iter_fragments(fragments, assistant_role):
+        for fragment in fragments or []:
+            fragment = fragment or {}
+            user_message = fragment.get("user_message") or ""
+            if user_message.strip():
+                yield ("user", user_message)
+            character_message = fragment.get("character_message") or ""
+            if character_message.strip():
+                yield (f"llm ({assistant_role})", character_message)
+
+    yield from _iter_fragments(workspace_history, main_role)
+    yield from _iter_fragments(coach_history, coach_role)
+    for fragment in evaluation_fragments or []:
+        fragment = fragment or {}
+        character_message = fragment.get("character_message") or ""
+        if character_message.strip():
+            yield ("llm (Evaluator)", character_message)
 
 
 def _extract_data(block):
@@ -176,18 +227,21 @@ def _extract_data(block):
         data = FieldDataCache([], block.course_id, user)
         data.add_blocks_to_cache([block])
 
-        try:
-            sessions = data.get(DjangoKeyValueStore.Key(
-                scope=Scope.user_state,
-                user_id=user.id,
-                block_scope_id=block.location,
-                field_name='sessions'
-            ))
-        except KeyError:
-            continue
-
-        for idx, session in enumerate(sessions, start=1):
-            for source, content in _get_messages(block, session):
+        if isinstance(block, CoachAIEvalXBlock):
+            workspace_history = _get_user_state_value(
+                data, block, user, "workspace_history", default=[]
+            )
+            coach_history = _get_user_state_value(
+                data, block, user, "coach_history", default=[]
+            )
+            evaluation_fragments = _get_user_state_value(
+                data, block, user, "evaluation_fragments", default=[]
+            )
+            if not workspace_history and not coach_history and not evaluation_fragments:
+                continue
+            for source, content in _iter_coach_messages(
+                block, workspace_history, coach_history, evaluation_fragments
+            ):
                 yield (
                     section_name,
                     subsection_name,
@@ -196,10 +250,35 @@ def _extract_data(block):
                     block.display_name,
                     user.username,
                     user.email or "",
-                    idx,
+                    1,
                     source,
                     content,
                 )
+        else:
+            try:
+                sessions = data.get(DjangoKeyValueStore.Key(
+                    scope=Scope.user_state,
+                    user_id=user.id,
+                    block_scope_id=block.location,
+                    field_name='sessions'
+                ))
+            except KeyError:
+                continue
+
+            for idx, session in enumerate(sessions, start=1):
+                for source, content in _get_messages(block, session):
+                    yield (
+                        section_name,
+                        subsection_name,
+                        unit_name,
+                        str(block.location),
+                        block.display_name,
+                        user.username,
+                        user.email or "",
+                        idx,
+                        source,
+                        content,
+                    )
 
 
 def _get_context(block):


### PR DESCRIPTION
## Description

This PR updates the AI conversation history export script as follows:
1. Course title is added as the first column of the report
2. Multiagent XBlock data is replaced with Coach AI XBlock data

## Supporting information

OpenCraft Internal Jira task: [BB-10439](https://tasks.opencraft.com/browse/BB-10439)

## Testing instructions

1. Install this branch of the XBlock.
2. Interact with a few of the AI XBlocks (short answer, coding and coaching).
3. Login as staff and add `ai_eval_export` in the advanced module list and add it anywhere in the course and publish.
4. Open the published LMS page as staff and generate and download the report.
5. Verify that the report contains the course name as the first column and it includes the coaching xblock conversation history.
