### PR TITLE
fix: Move judge0 API key to config and disable studio API-keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ API URLs are only required and used with the LLAMA model (`ollama/llama2`). Othe
 For better security, we recommend using site configuration or Django settings instead of configuring API keys at the 
 XBlock level. This prevents API keys from being exposed in course exports.
 
+Studio behavior:
+- `Chosen model API Key` is disabled in Studio when either:
+  - a model API key is already available via Site Configuration or Django `XBLOCK_SETTINGS`, or
+  - `USE_CUSTOM_LLM_SERVICE` is enabled.
+  This lock is model-specific: changing the selected model can enable/disable the field based on that model's configured key.
+
 ### Custom LLM Service (advanced)
 
 The XBlocks can optionally route all LLM interactions through a custom LLM service instead of the default provider.
@@ -149,14 +155,21 @@ Notes
 - Asynchronous model: `submit_endpoint` should return an identifier (e.g., `submission_id` or `id`) that is later used to poll `results_endpoint`.
 - `results_endpoint` must include `{submission_id}` and return execution status and outputs when ready.
 - `languages_endpoint` is called during initialization to verify supported languages.
-- To use Judge0, remove the custom backend settings or set `backend='judge0'`. Provide the Judge0 API key in the XBlock configuration. Optionally set `judge0_config.base_url`; otherwise the default RapidAPI endpoint is used.
+- To use self-hosted Judge0, set `backend='judge0'`.
+  - If `AI_EVAL_CODE_EXECUTION_BACKEND` is defined, provide `judge0_config.api_key` in Django settings.
+  - If `AI_EVAL_CODE_EXECUTION_BACKEND` is not defined, the per-XBlock `Judge0 API Key` field is used.
+  - Optionally set `judge0_config.base_url`; otherwise the default RapidAPI endpoint is used.
+- Studio disables the per-XBlock `Judge0 API Key` field when
+  `AI_EVAL_CODE_EXECUTION_BACKEND.backend='judge0'` and
+  `judge0_config.api_key` is provided in runtime settings.
 
 Example Judge0 configuration
 ```python
-# Optional override for Judge0 base URL; API key is set per XBlock instance
+# Self-hosted Judge0 API key and base URL come from Django settings
 AI_EVAL_CODE_EXECUTION_BACKEND = {
     'backend': 'judge0',
     'judge0_config': {
+        'api_key': 'your-judge0-api-key',
         'base_url': 'https://judge0-ce.p.rapidapi.com',
     },
 }

--- a/ai_eval/backends/factory.py
+++ b/ai_eval/backends/factory.py
@@ -14,18 +14,16 @@ class BackendFactory:
         """
         Get the appropriate backend based on Django settings.
 
-        Args:
-            api_key: Judge0 API key (only used for judge0 backend)
-
         Returns:
             CodeExecutionBackend: Configured backend instance
         """
-        backend_config = getattr(
-            django_conf.settings, 'AI_EVAL_CODE_EXECUTION_BACKEND', {}
+        raw_backend_config = getattr(
+            django_conf.settings, 'AI_EVAL_CODE_EXECUTION_BACKEND', None
         )
+        has_backend_config = raw_backend_config is not None
 
-        if backend_config.get('backend') == 'custom':
-            config = backend_config.get('custom_config', {})
+        if has_backend_config and raw_backend_config.get('backend') == 'custom':
+            config = raw_backend_config.get('custom_config', {})
             return CustomServiceBackend(
                 submit_endpoint=config.get('submit_endpoint', ''),
                 results_endpoint=config.get('results_endpoint', ''),
@@ -37,8 +35,17 @@ class BackendFactory:
             )
 
         # Default to judge0 backend
-        judge0_config = backend_config.get('judge0_config', {})
+        judge0_config = (
+            raw_backend_config.get('judge0_config', {})
+            if has_backend_config
+            else {}
+        )
+        judge0_api_key = (
+            judge0_config.get('api_key', '')
+            if has_backend_config
+            else api_key
+        )
         return Judge0Backend(
-            api_key=api_key,
+            api_key=judge0_api_key,
             base_url=judge0_config.get('base_url')
         )

--- a/ai_eval/backends/factory.py
+++ b/ai_eval/backends/factory.py
@@ -17,6 +17,9 @@ class BackendFactory:
         Returns:
             CodeExecutionBackend: Configured backend instance
         """
+        # Keep `None` as the default so we can distinguish "setting absent"
+        # from "setting present but incomplete". We only fall back to the
+        # per-block `api_key` when the backend setting is truly absent.
         raw_backend_config = getattr(
             django_conf.settings, 'AI_EVAL_CODE_EXECUTION_BACKEND', None
         )

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -150,7 +150,10 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
 
         if config_parameter == "api_key":
             # When configured globally/site-wide, ignore XBlock-local model_api_key.
-            if value := self._get_site_or_global_model_config_value(config_parameter, obj):
+            if value := self._get_site_or_global_config_value(
+                config_parameter,
+                obj=obj,
+            ):
                 return value
             if value := getattr(obj, field_name, None):
                 return str(value)
@@ -175,23 +178,22 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
 
         return f"{model_name}_{config_parameter.upper()}"
 
-    def _get_site_or_global_model_config_value(
-        self, config_parameter: str, obj: Self = None
+    def _get_site_or_global_config_value(
+        self,
+        config_parameter: str,
+        obj: Self = None,
+        model: str | None = None,
     ) -> str | None:
         """
-        Return model config from site or global settings only (ignores XBlock-local fields).
-        """
-        obj = obj or self
-        return self._get_site_or_global_model_config_value_for_model(
-            getattr(obj, "model", None), config_parameter
-        )
+        Return model config from site/global settings.
 
-    def _get_site_or_global_model_config_value_for_model(
-        self, model: str | None, config_parameter: str
-    ) -> str | None:
+        If `model` is provided, it is used directly. Otherwise, model is read
+        from `obj.model` (or `self.model` when obj is omitted).
         """
-        Return model config from site/global settings for an explicit model name.
-        """
+        if model is None:
+            obj = obj or self
+            model = getattr(obj, "model", None)
+
         if not model:
             return None
 
@@ -224,11 +226,12 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Lock model API key field when custom LLM service is enabled or key is globally provided.
         """
-        obj = obj or self
-        model = getattr(obj, "model", None)
         return bool(
             self._is_custom_llm_service_enabled()
-            or self._get_site_or_global_model_config_value_for_model(model, "api_key")
+            or self._get_site_or_global_config_value(
+                "api_key",
+                obj=obj,
+            )
         )
 
     def _get_model_key_presence_map(self) -> dict[str, bool]:
@@ -240,7 +243,12 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
             models.append(self.model)
 
         return {
-            model: bool(self._get_site_or_global_model_config_value_for_model(model, "api_key"))
+            model: bool(
+                self._get_site_or_global_config_value(
+                    "api_key",
+                    model=model,
+                )
+            )
             for model in models
         }
 

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -2,7 +2,7 @@
 from typing import Self
 
 import logging
-import pkg_resources
+from importlib.resources import files
 from django.core.cache import cache
 
 from django.utils.translation import gettext_noop as _
@@ -122,8 +122,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
-        data = pkg_resources.resource_string(__name__, path)
-        return data.decode("utf8")
+        return files("ai_eval").joinpath(path).read_text(encoding="utf8")
 
     def _get_model_config_value(self, config_parameter: str, obj: Self = None) -> str | None:
         """

--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -129,10 +129,15 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Get configuration value for the model provider with a fallback chain.
 
-        Checks for the value in the following order:
-        1. XBlock field (model_api_key or model_api_url)
+        For `api_key`, checks:
+        1. Site configuration
+        2. XBlock settings (defined in Django settings)
+        3. XBlock field (model_api_key)
+
+        For other parameters (e.g. `api_url`), checks:
+        1. XBlock field
         2. Site configuration
-        3. XBlock settings (defined in Django settings)
+        3. XBlock settings
 
         Args:
             config_parameter: Parameter to retrieve (e.g., "API_KEY" or "API_URL").
@@ -144,24 +149,123 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         obj = obj or self
         field_name = f"model_{config_parameter}"
 
-        # For custom models, use the model name directly; for supported models, use the enum name
-        try:
-            model_name = SupportedModels(obj.model).name
-        except ValueError:
-            model_name = obj.model.replace("/", "_").replace("-", "_").upper()
+        if config_parameter == "api_key":
+            # When configured globally/site-wide, ignore XBlock-local model_api_key.
+            if value := self._get_site_or_global_model_config_value(config_parameter, obj):
+                return value
+            if value := getattr(obj, field_name, None):
+                return str(value)
+            return None
 
-        config_key = f"{model_name}_{config_parameter.upper()}"
+        config_key = self._get_model_config_key(obj.model, config_parameter)
 
-        # XBlock field
         if value := getattr(obj, field_name, None):
             return str(value)
-
-        # Site configuration
         if value := get_site_configuration_value(self.block_settings_key, config_key):
             return value
-
-        # XBlock settings
         return self._get_settings().get(config_key)
+
+    @staticmethod
+    def _get_model_config_key(model: str, config_parameter: str) -> str:
+        """Build model configuration key name for site/global settings lookups."""
+        # For custom models, use the model name directly; for supported models, use the enum name
+        try:
+            model_name = SupportedModels(model).name
+        except ValueError:
+            model_name = model.replace("/", "_").replace("-", "_").upper()
+
+        return f"{model_name}_{config_parameter.upper()}"
+
+    def _get_site_or_global_model_config_value(
+        self, config_parameter: str, obj: Self = None
+    ) -> str | None:
+        """
+        Return model config from site or global settings only (ignores XBlock-local fields).
+        """
+        obj = obj or self
+        return self._get_site_or_global_model_config_value_for_model(
+            getattr(obj, "model", None), config_parameter
+        )
+
+    def _get_site_or_global_model_config_value_for_model(
+        self, model: str | None, config_parameter: str
+    ) -> str | None:
+        """
+        Return model config from site/global settings for an explicit model name.
+        """
+        if not model:
+            return None
+
+        config_key = self._get_model_config_key(model, config_parameter)
+        if value := get_site_configuration_value(self.block_settings_key, config_key):
+            return value
+        return self._get_settings().get(config_key)
+
+    @staticmethod
+    def _is_truthy(value) -> bool:
+        """
+        Normalize booleans that may be provided as strings.
+        """
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _is_custom_llm_service_enabled(self) -> bool:
+        """
+        Check if custom LLM service is enabled via site/global config.
+        """
+        site_value = get_site_configuration_value(self.block_settings_key, "USE_CUSTOM_LLM_SERVICE")
+        if site_value is not None:
+            return self._is_truthy(site_value)
+        return self._is_truthy(self._get_settings().get("USE_CUSTOM_LLM_SERVICE"))
+
+    def should_lock_model_api_key_field(self, obj: Self = None) -> bool:
+        """
+        Lock model API key field when custom LLM service is enabled or key is globally provided.
+        """
+        obj = obj or self
+        model = getattr(obj, "model", None)
+        return bool(
+            self._is_custom_llm_service_enabled()
+            or self._get_site_or_global_model_config_value_for_model(model, "api_key")
+        )
+
+    def _get_model_key_presence_map(self) -> dict[str, bool]:
+        """
+        Return a map of model name -> whether an API key is configured site/global.
+        """
+        models = list(SupportedModels.list())
+        if self.model and self.model not in models:
+            models.append(self.model)
+
+        return {
+            model: bool(self._get_site_or_global_model_config_value_for_model(model, "api_key"))
+            for model in models
+        }
+
+    def _get_studio_lock_payload(self) -> dict:
+        """
+        Return Studio-side lock metadata for API key fields.
+        """
+        return {
+            "use_custom_llm_service": self._is_custom_llm_service_enabled(),
+            "initial_model": self.model or "",
+            "model_key_presence": self._get_model_key_presence_map(),
+            "lock_model_api_key_initial": self.should_lock_model_api_key_field(),
+            "lock_judge0_api_key": False,
+        }
+
+    def studio_view(self, context):
+        """
+        Render Studio editor and initialize API-key field lock behavior.
+        """
+        fragment = super().studio_view(context)
+        fragment.add_css(self.resource_string("static/css/studio_api_key_lock.css"))
+        fragment.add_javascript(self.resource_string("static/js/src/studio_api_key_lock.js"))
+        fragment.initialize_js("AIEvalStudioEditor", self._get_studio_lock_payload())
+        return fragment
 
     def get_model_api_key(self, obj: Self = None) -> str | None:
         """Get the API key for the model provider."""

--- a/ai_eval/coding_ai_eval.py
+++ b/ai_eval/coding_ai_eval.py
@@ -1,7 +1,7 @@
 """Coding Xblock with AI evaluation."""
 
 import logging
-import pkg_resources
+from importlib.resources import files
 
 from django.conf import settings
 from django.utils.translation import gettext_noop as _
@@ -109,8 +109,7 @@ class CodingAIEvalXBlock(AIEvalXBlock):
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
-        data = pkg_resources.resource_string(__name__, path)
-        return data.decode("utf8")
+        return files("ai_eval").joinpath(path).read_text(encoding="utf8")
 
     def student_view(self, context=None):
         """

--- a/ai_eval/coding_ai_eval.py
+++ b/ai_eval/coding_ai_eval.py
@@ -164,6 +164,32 @@ class CodingAIEvalXBlock(AIEvalXBlock):
 
         return self.student_view(context=context)
 
+    def _get_code_execution_backend_config(self):
+        """Return code execution backend config from Django settings, or None if absent."""
+        return getattr(settings, 'AI_EVAL_CODE_EXECUTION_BACKEND', None)
+
+    def _is_judge0_backend_selected(self) -> bool:
+        """Return true when the configured backend is judge0 (default)."""
+        backend_config = self._get_code_execution_backend_config() or {}
+        backend_name = backend_config.get('backend', 'judge0')
+        return backend_name == 'judge0'
+
+    def _is_judge0_api_key_configured(self) -> bool:
+        """Return true when Judge0 API key is present in Django settings config."""
+        backend_config = self._get_code_execution_backend_config() or {}
+        judge0_config = backend_config.get('judge0_config', {})
+        return bool(judge0_config.get('api_key'))
+
+    def should_lock_judge0_api_key_field(self) -> bool:
+        """Lock Judge0 field when runtime settings provide a Judge0 API key."""
+        return self._is_judge0_backend_selected() and self._is_judge0_api_key_configured()
+
+    def _get_studio_lock_payload(self) -> dict:
+        """Extend base lock payload with coding-specific Judge0 lock flag."""
+        payload = super()._get_studio_lock_payload()
+        payload["lock_judge0_api_key"] = self.should_lock_judge0_api_key_field()
+        return payload
+
     def validate_field_data(self, validation, data):
         """
         Validate fields
@@ -178,17 +204,30 @@ class CodingAIEvalXBlock(AIEvalXBlock):
                 )
             )
 
+        has_backend_config = self._get_code_execution_backend_config() is not None
+        missing_judge0_key = (
+            (has_backend_config and not self._is_judge0_api_key_configured())
+            or (not has_backend_config and not data.judge0_api_key)
+        )
+
         # Only enforce Judge0 API key when Judge0 backend is selected (or default)
-        backend_config = getattr(settings, 'AI_EVAL_CODE_EXECUTION_BACKEND', {})
-        backend_name = backend_config.get('backend', 'judge0')
         if (
             data.language != LanguageLabels.HTML_CSS
-            and backend_name != 'custom'
-            and not data.judge0_api_key
+            and self._is_judge0_backend_selected()
+            and missing_judge0_key
         ):
+            error_message = (
+                _(
+                    "Judge0 API key is mandatory in Django settings when "
+                    "AI_EVAL_CODE_EXECUTION_BACKEND is configured."
+                )
+                if has_backend_config
+                else _("Judge0 API key is mandatory")
+            )
             validation.add(
                 ValidationMessage(
-                    ValidationMessage.ERROR, _("Judge0 API key is mandatory")
+                    ValidationMessage.ERROR,
+                    error_message,
                 )
             )
 

--- a/ai_eval/export.py
+++ b/ai_eval/export.py
@@ -26,7 +26,7 @@ Instructor Tool: An XBlock for instructors to export student answers from a cour
 All processing is done offline.
 """
 import json
-import pkg_resources
+from importlib.resources import files
 
 from django.utils.translation import gettext_noop as _
 from web_fragments.fragment import Fragment
@@ -91,8 +91,7 @@ class DataExportXBlock(XBlock):
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
-        data = pkg_resources.resource_string(__name__, path)
-        return data.decode("utf8")
+        return files("ai_eval").joinpath(path).read_text(encoding="utf8")
 
     def student_view(self, context=None):
         """ Normal View """

--- a/ai_eval/static/css/studio_api_key_lock.css
+++ b/ai_eval/static/css/studio_api_key_lock.css
@@ -1,0 +1,24 @@
+/* Keep locked API-key settings visually disabled even on hover/focus in Studio. */
+.xblock-studio_view .ai-eval-locked-entry .field-data-control,
+.xblock-studio_view .ai-eval-locked-entry .field-data-control:hover,
+.xblock-studio_view .ai-eval-locked-entry .field-data-control:focus {
+    background-color: #f2f2f2 !important;
+    border-color: #b2b2b2 !important;
+    color: #4c4c4c !important;
+    cursor: not-allowed !important;
+    box-shadow: none !important;
+}
+
+.xblock-studio_view .ai-eval-locked-entry:hover {
+    background-color: #f7f7f7 !important;
+}
+
+.xblock-studio_view .ai-eval-locked-entry .action.setting-clear {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+.xblock-studio_view .ai-eval-lock-badge {
+    color: #666;
+    font-weight: 600;
+}

--- a/ai_eval/static/js/src/studio_api_key_lock.js
+++ b/ai_eval/static/js/src/studio_api_key_lock.js
@@ -1,0 +1,99 @@
+/* Javascript for lock-aware Studio editor behavior on API key fields. */
+function AIEvalStudioEditor(runtime, element, data) {
+    "use strict";
+
+    StudioEditableXBlockMixin(runtime, element);
+
+    var rootElement = (element && element[0]) ? element[0] : element;
+    if (!rootElement || typeof rootElement.querySelector !== "function") {
+        return;
+    }
+
+    var modelField = rootElement.querySelector("#xb-field-edit-model");
+    var modelApiKeyField = rootElement.querySelector("#xb-field-edit-model_api_key");
+    var judge0ApiKeyField = rootElement.querySelector("#xb-field-edit-judge0_api_key");
+    var modelApiKeyLabel = rootElement.querySelector("label[for='xb-field-edit-model_api_key']");
+    var judge0ApiKeyLabel = rootElement.querySelector("label[for='xb-field-edit-judge0_api_key']");
+
+    var useCustomService = Boolean(data && data.use_custom_llm_service);
+    var modelKeyPresence = (data && data.model_key_presence) || {};
+    var lockBadgeClass = "ai-eval-lock-badge";
+    var lockedEntryClass = "ai-eval-locked-entry";
+
+    var setDisabled = function(field, disabled) {
+        if (!field) {
+            return;
+        }
+
+        field.disabled = Boolean(disabled);
+        if (field.disabled) {
+            field.setAttribute("aria-disabled", "true");
+        } else {
+            field.removeAttribute("aria-disabled");
+        }
+
+        var settingEntry = field.closest("li");
+        if (!settingEntry) {
+            return;
+        }
+
+        if (field.disabled) {
+            settingEntry.classList.add(lockedEntryClass);
+        } else {
+            settingEntry.classList.remove(lockedEntryClass);
+        }
+    };
+
+    var setLockBadge = function(label, locked) {
+        if (!label) {
+            return;
+        }
+
+        var badge = label.querySelector("." + lockBadgeClass);
+        if (locked) {
+            if (!badge) {
+                badge = document.createElement("span");
+                badge.className = lockBadgeClass;
+                badge.textContent = " (Locked by admin)";
+                label.appendChild(badge);
+            }
+            return;
+        }
+
+        if (badge) {
+            badge.remove();
+        }
+    };
+
+    var getSelectedModel = function() {
+        if (modelField && typeof modelField.value === "string") {
+            return modelField.value;
+        }
+        return (data && data.initial_model) || "";
+    };
+
+    var isModelApiKeyLocked = function(model) {
+        if (useCustomService) {
+            return true;
+        }
+        if (Object.prototype.hasOwnProperty.call(modelKeyPresence, model)) {
+            return Boolean(modelKeyPresence[model]);
+        }
+        return Boolean(data && data.lock_model_api_key_initial);
+    };
+
+    var syncModelApiKeyLock = function() {
+        var isLocked = isModelApiKeyLocked(getSelectedModel());
+        setDisabled(modelApiKeyField, isLocked);
+        setLockBadge(modelApiKeyLabel, isLocked);
+    };
+
+    var judge0Locked = Boolean(data && data.lock_judge0_api_key);
+    setDisabled(judge0ApiKeyField, judge0Locked);
+    setLockBadge(judge0ApiKeyLabel, judge0Locked);
+    syncModelApiKeyLock();
+
+    if (modelField) {
+        modelField.addEventListener("change", syncModelApiKeyLock);
+    }
+}

--- a/ai_eval/static/js/src/studio_api_key_lock.js
+++ b/ai_eval/static/js/src/studio_api_key_lock.js
@@ -76,7 +76,7 @@ function AIEvalStudioEditor(runtime, element, data) {
         if (useCustomService) {
             return true;
         }
-        if (Object.prototype.hasOwnProperty.call(modelKeyPresence, model)) {
+        if (modelKeyPresence.hasOwnProperty(model)) {
             return Boolean(modelKeyPresence[model]);
         }
         return Boolean(data && data.lock_model_api_key_initial);

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -5,6 +5,7 @@ Testing module.
 
 import urllib.request
 import io
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -267,6 +268,39 @@ def test_backend_factory_selection(backend_config, expected_backend_class):
         assert isinstance(backend, expected_backend_class)
 
 
+def test_backend_factory_uses_judge0_config_api_key():
+    """Judge0 backend should source API key from Django backend config."""
+    with patch('django.conf.settings') as mock_settings:
+        mock_settings.AI_EVAL_CODE_EXECUTION_BACKEND = {
+            'backend': 'judge0',
+            'judge0_config': {
+                'api_key': 'config-key',
+                'base_url': 'http://localhost:2358',
+            },
+        }
+        backend = BackendFactory.get_backend()
+        assert isinstance(backend, Judge0Backend)
+        assert backend.api_key == "config-key"
+        assert backend.base_url == "http://localhost:2358"
+
+
+def test_backend_factory_uses_xblock_judge0_key_when_backend_config_absent():
+    """Judge0 backend should use XBlock key when backend setting is not configured."""
+    with patch('django.conf.settings', new=SimpleNamespace()):
+        backend = BackendFactory.get_backend(api_key="xblock-key")
+        assert isinstance(backend, Judge0Backend)
+        assert backend.api_key == "xblock-key"
+
+
+def test_backend_factory_does_not_fallback_when_backend_config_present_but_empty():
+    """Judge0 backend should ignore XBlock key when backend setting exists, even if empty."""
+    with patch('django.conf.settings') as mock_settings:
+        mock_settings.AI_EVAL_CODE_EXECUTION_BACKEND = {}
+        backend = BackendFactory.get_backend(api_key="xblock-key")
+        assert isinstance(backend, Judge0Backend)
+        assert backend.api_key == ""
+
+
 def test_judge0_backend_initialization():
     """Test Judge0Backend initializes with correct API key."""
     backend = Judge0Backend(api_key="test-key")
@@ -433,8 +467,10 @@ def test_custom_get_result(mock_get):
 @pytest.mark.parametrize(
     "xblock_key, site_config_key, settings_dict, expected_result",
     [
-        # XBlock field is prioritized
-        ("xblock-key", "site-config-key", {"GPT4O_API_KEY": "settings-key"}, "xblock-key"),
+        # Site configuration takes precedence over XBlock field for API keys
+        ("xblock-key", "site-config-key", {"GPT4O_API_KEY": "settings-key"}, "site-config-key"),
+        # Global settings take precedence over XBlock field for API keys
+        ("xblock-key", None, {"GPT4O_API_KEY": "settings-key"}, "settings-key"),
         # Fall back to site configuration
         ("", "site-config-key", {"GPT4O_API_KEY": "settings-key"}, "site-config-key"),
         # Fall back to settings
@@ -448,22 +484,12 @@ def test_get_model_config_value_fallback_chain(
 ):
     """
     Test API key fallback chain with different scenarios.
-
-    This tests the core fallback logic which is also used for API URLs.
     """
     ai_eval_block.model_api_key = xblock_key
     ai_eval_block._get_settings = Mock(return_value=settings_dict)
 
-    with patch("ai_eval.base.get_site_configuration_value", return_value=site_config_key) as mock_site_config:
+    with patch("ai_eval.base.get_site_configuration_value", return_value=site_config_key):
         api_key = ai_eval_block.get_model_api_key()
-
-        if not xblock_key:
-            mock_site_config.assert_called_once_with(ai_eval_block.block_settings_key, "GPT4O_API_KEY")
-
-    if not site_config_key and not xblock_key:
-        ai_eval_block._get_settings.assert_called_once()
-    else:
-        ai_eval_block._get_settings.assert_not_called()
 
     assert api_key == expected_result
 
@@ -493,6 +519,7 @@ def test_coding_block_submit_code_uses_backend(mock_get_backend, coding_block_da
     result = block.submit_code_handler.__wrapped__(block, data={"user_code": "print('hello')"})
 
     assert result == {"submission_id": "test-submission-id"}
+    mock_get_backend.assert_called_once_with(block.judge0_api_key)
     mock_backend.submit_code.assert_called_once_with("print('hello')", "Python (3.8.1)")
 
 
@@ -507,4 +534,122 @@ def test_coding_block_get_submission_result_uses_backend(mock_get_backend, codin
     result = block.get_submission_result_handler.__wrapped__(block, data={"submission_id": "test-id"})
 
     assert result == {"status": "Accepted"}
+    mock_get_backend.assert_called_once_with(block.judge0_api_key)
     mock_backend.get_result.assert_called_once_with("test-id")
+
+
+def test_should_lock_model_api_key_field_when_site_key_exists(ai_eval_block):
+    """Model API key field should lock when site/global key is available."""
+    ai_eval_block._get_settings = Mock(return_value={})
+    with patch("ai_eval.base.get_site_configuration_value", return_value="site-key"):
+        assert ai_eval_block.should_lock_model_api_key_field()
+
+
+def test_should_lock_model_api_key_field_when_custom_service_enabled(ai_eval_block):
+    """Model API key field should lock when custom LLM service is enabled."""
+    ai_eval_block._get_settings = Mock(return_value={})
+    with patch("ai_eval.base.get_site_configuration_value", return_value=True):
+        assert ai_eval_block.should_lock_model_api_key_field()
+
+
+def test_should_not_lock_model_api_key_field_without_site_key_or_custom_service(ai_eval_block):
+    """Model API key field should remain editable without global/site key and custom LLM."""
+    ai_eval_block._get_settings = Mock(return_value={})
+    with patch("ai_eval.base.get_site_configuration_value", return_value=None):
+        assert not ai_eval_block.should_lock_model_api_key_field()
+
+
+def test_studio_lock_payload_locks_model_api_key_when_locked(ai_eval_block):
+    """Studio payload should lock model API key when globally configured."""
+    ai_eval_block._get_settings = Mock(return_value={})
+    with patch("ai_eval.base.get_site_configuration_value", return_value="site-key"):
+        payload = ai_eval_block._get_studio_lock_payload()
+        assert payload["lock_model_api_key_initial"] is True
+
+
+def test_studio_lock_payload_keeps_model_api_key_unlocked_without_config(ai_eval_block):
+    """Studio payload should keep model API key editable without global/site config."""
+    ai_eval_block._get_settings = Mock(return_value={})
+    with patch("ai_eval.base.get_site_configuration_value", return_value=None):
+        payload = ai_eval_block._get_studio_lock_payload()
+        assert payload["lock_model_api_key_initial"] is False
+        assert payload["model_key_presence"][SupportedModels.GPT4O.value] is False
+
+
+def test_should_lock_judge0_api_key_field_when_backend_has_judge0_key(coding_block_data):
+    """Judge0 field should lock when runtime settings provide judge0 backend key."""
+    block = CodingAIEvalXBlock(ToyRuntime(), DictFieldData(coding_block_data), None)
+    with patch(
+        'ai_eval.coding_ai_eval.settings',
+        new=SimpleNamespace(
+            AI_EVAL_CODE_EXECUTION_BACKEND={
+                "backend": "judge0",
+                "judge0_config": {"api_key": "config-key"},
+            }
+        ),
+    ):
+        assert block.should_lock_judge0_api_key_field()
+
+
+def test_should_not_lock_judge0_api_key_field_when_backend_setting_absent(coding_block_data):
+    """Judge0 field should be editable when backend setting is absent."""
+    block = CodingAIEvalXBlock(ToyRuntime(), DictFieldData(coding_block_data), None)
+    with patch('ai_eval.coding_ai_eval.settings', new=SimpleNamespace()):
+        assert not block.should_lock_judge0_api_key_field()
+
+
+def test_should_not_lock_judge0_api_key_field_without_runtime_judge0_key(coding_block_data):
+    """Judge0 field should remain editable when runtime judge0 key is missing."""
+    block = CodingAIEvalXBlock(ToyRuntime(), DictFieldData(coding_block_data), None)
+    with patch(
+        'ai_eval.coding_ai_eval.settings',
+        new=SimpleNamespace(
+            AI_EVAL_CODE_EXECUTION_BACKEND={
+                "backend": "judge0",
+                "judge0_config": {},
+            }
+        ),
+    ):
+        assert not block.should_lock_judge0_api_key_field()
+
+
+def test_should_not_lock_judge0_api_key_field_for_custom_backend(coding_block_data):
+    """Judge0 field should remain editable when runtime backend is custom."""
+    block = CodingAIEvalXBlock(ToyRuntime(), DictFieldData(coding_block_data), None)
+    with patch(
+        'ai_eval.coding_ai_eval.settings',
+        new=SimpleNamespace(
+            AI_EVAL_CODE_EXECUTION_BACKEND={
+                "backend": "custom",
+                "custom_config": {"api_key": "custom-key"},
+            }
+        ),
+    ):
+        assert not block.should_lock_judge0_api_key_field()
+
+
+def test_coding_studio_lock_payload_sets_judge0_lock_flag(coding_block_data):
+    """Coding Studio payload should include judge0 lock flag when runtime key is configured."""
+    block = CodingAIEvalXBlock(ToyRuntime(), DictFieldData(coding_block_data), None)
+    block._get_settings = Mock(return_value={})
+    with patch(
+        'ai_eval.coding_ai_eval.settings',
+        new=SimpleNamespace(
+            AI_EVAL_CODE_EXECUTION_BACKEND={
+                "backend": "judge0",
+                "judge0_config": {"api_key": "config-key"},
+            }
+        ),
+    ), patch("ai_eval.base.get_site_configuration_value", return_value=None):
+        payload = block._get_studio_lock_payload()
+        assert payload["lock_judge0_api_key"] is True
+
+
+def test_coding_studio_lock_payload_unsets_judge0_lock_flag_without_runtime_key(coding_block_data):
+    """Coding Studio payload should not lock judge0 field without runtime judge0 key."""
+    block = CodingAIEvalXBlock(ToyRuntime(), DictFieldData(coding_block_data), None)
+    block._get_settings = Mock(return_value={})
+    with patch('ai_eval.coding_ai_eval.settings', new=SimpleNamespace()), \
+            patch("ai_eval.base.get_site_configuration_value", return_value=None):
+        payload = block._get_studio_lock_payload()
+        assert payload["lock_judge0_api_key"] is False


### PR DESCRIPTION
## Description

This PR updates the AI Evaluation Studio flow so self-hosted Judge0 API keys are now read from platform configuration instead of relying on per-XBlock field values. It also locks API key fields in Studio when the required keys are already configured at the site/global level.

## Supporting information

OpenCraft Internal Jira task - https://tasks.opencraft.com/browse/BB-10538

## Testing instructions

1. Deploy this branch.
2. Without any site config changes, verify that the model api key field is editable for any of the XBlock (coding or short answer or coaching).
3. Add a model api key in the site config as described [here](https://github.com/open-craft/xblock-ai-evaluation/tree/pooja/bb10538-config-judge0-api-key?tab=readme-ov-file#api-configuration) in the README.
4. In the xblock settings editor, chose the corresponding model from the dropdown and verify that the model api key field is locked (not editable).
5. Go back to the site config, remove the api key and set `"USE_CUSTOM_LLM_SERVICE": true`.
6. Since we haven't completed the custom llm service setup, the xblock settings will fail to save but you can verify that the model api key field is locked.
7. Set Judge0 configuration as described [here](https://github.com/open-craft/xblock-ai-evaluation/tree/pooja/bb10538-config-judge0-api-key?tab=readme-ov-file#custom-code-execution-service-advanced) in the README.
8. In the coding XBlock editor, verify that the Judge0 api key field is also locked (not editable).

