### PR TITLE
fix: use shared HTTP timeout for custom LLM requests

### DIFF
--- a/ai_eval/llm_services.py
+++ b/ai_eval/llm_services.py
@@ -7,6 +7,7 @@ import requests
 from litellm import completion
 from .supported_models import SupportedModels
 from .compat import get_site_configuration_value
+from .utils import DEFAULT_HTTP_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +119,7 @@ class CustomLLMService(LLMServiceBase):
             'scope': 'ml.chatbot.query'
         }
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-        response = requests.post(self.token_url, data=data, headers=headers, timeout=30)
+        response = requests.post(self.token_url, data=data, headers=headers, timeout=DEFAULT_HTTP_TIMEOUT)
         response.raise_for_status()
         token_data = response.json()
         self._access_token = token_data['access_token']
@@ -213,7 +214,7 @@ class CustomLLMService(LLMServiceBase):
             "prompt": prompt,
         }
         try:
-            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=10)
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=DEFAULT_HTTP_TIMEOUT)
             response.raise_for_status()
             data = response.json()
             text = data.get("response")
@@ -231,7 +232,7 @@ class CustomLLMService(LLMServiceBase):
                 logger.warning("CUSTOM_LLM_MODELS_URL not configured")
                 return []
 
-            response = requests.get(url, headers=self._get_headers(), timeout=30)
+            response = requests.get(url, headers=self._get_headers(), timeout=DEFAULT_HTTP_TIMEOUT)
             response.raise_for_status()
             data = response.json()
 

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -25,7 +25,7 @@ from ai_eval.llm_services import CustomLLMService
 from ai_eval.backends.factory import BackendFactory
 from ai_eval.backends.judge0 import Judge0Backend
 from ai_eval.backends.custom import CustomServiceBackend
-from ai_eval.utils import SUPPORTED_LANGUAGE_MAP, LanguageLabels
+from ai_eval.utils import DEFAULT_HTTP_TIMEOUT, SUPPORTED_LANGUAGE_MAP, LanguageLabels
 
 
 def _mock_handler_url(_block, handler_name, suffix='', query='', thirdparty=False):
@@ -1253,6 +1253,32 @@ def test_custom_llm_models_dict_response_parsed():
 
     with patch("ai_eval.llm_services.requests.get", return_value=mocked_response):
         assert service.get_available_models() == ["Meta-Llama4-Maverick", "gpt-4o"]
+
+
+def test_custom_llm_completion_uses_default_http_timeout():
+    """Custom completion requests use the shared outbound HTTP timeout."""
+    service = CustomLLMService(
+        models_url="https://example.com/models",
+        completions_url="https://example.com/completions",
+        token_url="https://example.com/token",
+        client_id="client",
+        client_secret="secret",
+    )
+    service._get_headers = Mock(return_value={"Authorization": "Bearer token"})  # pylint: disable=protected-access
+
+    mocked_response = Mock()
+    mocked_response.json.return_value = {"response": "Feedback"}
+    mocked_response.raise_for_status.return_value = None
+
+    with patch("ai_eval.llm_services.requests.post", return_value=mocked_response) as mock_post:
+        assert service.get_response(
+            model="gpt-4o",
+            api_key="",
+            messages=[{"role": "user", "content": "Answer"}],
+            api_base=None,
+        ) == ("Feedback", None)
+
+    assert mock_post.call_args.kwargs["timeout"] == DEFAULT_HTTP_TIMEOUT
 
 
 @pytest.mark.parametrize(

--- a/ai_eval/utils.py
+++ b/ai_eval/utils.py
@@ -5,7 +5,7 @@ Utilities
 from dataclasses import dataclass
 
 
-# Default timeout (in seconds) for outbound HTTP requests made by backends.
+# Default timeout (in seconds) for outbound HTTP requests.
 # Adjust here to change the global default behavior.
 DEFAULT_HTTP_TIMEOUT = 30
 


### PR DESCRIPTION
Quick fix to ensure the custom LLM requests use the shared HTTP timeout. The timeout will be made configurable via settings later.

