### PR TITLE
docs: add claude API key docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The system will check for these configurations in the following order:
     {
         "ai_eval": {
              "GPT4O_API_KEY": "your-openai-api-key",
+             "CLAUDE_SONNET_API_KEY": "your-anthropic-api-key",
              "LLAMA_API_URL": "https://your-llama-endpoint"
         }
     }
@@ -104,6 +105,7 @@ The system will check for these configurations in the following order:
    XBLOCK_SETTINGS = {
        "ai_eval": {
            "GPT4O_API_KEY": "your-openai-api-key",
+           "CLAUDE_SONNET_API_KEY": "your-anthropic-api-key",
            "LLAMA_API_URL": "https://your-llama-endpoint"
         }
     }


### PR DESCRIPTION
## Description

Make it clear how to set the CLAUDE_SONNET API key.

## Testing instructions

1. Install the block.
2. Set the API key in the site configuration according to the directions.
3. Create a block and select Claude Sonnet
4. Verify that the block picks up the key and locks the key field.
