### PR TITLE
[BB-10960] Replace retired Claude Sonnet 4 model with Sonnet 4.6

### DIFF
--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -14,7 +14,7 @@ from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xblock.validation import ValidationMessage
 
 from .compat import get_site_configuration_value
-from .supported_models import SupportedModels
+from .supported_models import SupportedModels, resolve_model
 from .llm import get_llm_response, get_llm_service
 
 
@@ -190,7 +190,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         """Build model configuration key name for site/global settings lookups."""
         # For custom models, use the model name directly; for supported models, use the enum name
         try:
-            model_name = SupportedModels(model).name
+            model_name = SupportedModels(resolve_model(model)).name
         except ValueError:
             model_name = model.replace("/", "_").replace("-", "_").upper()
 
@@ -535,6 +535,17 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
 
         self._clear_cached_studio_warnings()
 
+    @property
+    def effective_model(self) -> str:
+        """
+        The model identifier to use at runtime.
+
+        Resolves any provider-retired/renamed model saved on the block to its
+        current replacement, so activities configured with a legacy model keep
+        working without editing course content.
+        """
+        return resolve_model(self.model)
+
     def get_llm_response(self, messages, tag: str | None = None):
         """
         Call the shared LLM entrypoint and return only the response text.
@@ -547,7 +558,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
                 prior_thread_id = None
 
         text, new_thread_id = get_llm_response(
-            self.model,
+            self.effective_model,
             self.get_model_api_key(),
 
             list(messages), self.get_model_api_url(),

--- a/ai_eval/coach.py
+++ b/ai_eval/coach.py
@@ -886,7 +886,7 @@ class CoachAIEvalXBlock(AIEvalXBlock):
 
         def _generate():
             yield {"role": "system", "content": prompt}
-            if self.model == SupportedModels.CLAUDE_SONNET.value:
+            if self.effective_model == SupportedModels.CLAUDE_SONNET.value:
                 # Claude needs a dummy user reply before the first assistant reply.
                 yield {"role": "user", "content": "."}
 
@@ -1241,7 +1241,7 @@ class CoachAIEvalXBlock(AIEvalXBlock):
 
         def _evaluator_messages():
             yield {"role": "system", "content": prompt}
-            if self.model == SupportedModels.CLAUDE_SONNET.value:
+            if self.effective_model == SupportedModels.CLAUDE_SONNET.value:
                 yield {"role": "user", "content": "."}
 
         message = self.get_llm_response(

--- a/ai_eval/supported_models.py
+++ b/ai_eval/supported_models.py
@@ -11,10 +11,24 @@ class SupportedModels(Enum):
     GPT4O = "gpt-4o"
     GPT4O_MINI = "gpt-4o-mini"
     GEMINI_PRO = "gemini/gemini-pro"
-    CLAUDE_SONNET = "claude-sonnet-4-20250514"
+    CLAUDE_SONNET = "claude-sonnet-4-6"
     LLAMA = "ollama/llama2"
 
     @staticmethod
     def list():
         """Return the list of supported model values."""
         return [str(m.value) for m in SupportedModels]
+
+
+# Models retired or renamed by their providers, mapped to their drop-in
+# replacement. Activities saved with a legacy identifier keep working because
+# the value is resolved to its replacement at the point of use (the provider
+# call and the per-model API-key lookup), so no course content needs editing.
+LEGACY_MODEL_ALIASES = {
+    "claude-sonnet-4-20250514": "claude-sonnet-4-6",
+}
+
+
+def resolve_model(model: str) -> str:
+    """Resolve a possibly-legacy model identifier to its current replacement."""
+    return LEGACY_MODEL_ALIASES.get(model, model)

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -20,7 +20,7 @@ from ai_eval import (
     ShortAnswerAIEvalXBlock,
 )
 from ai_eval.base import AIEvalXBlock
-from ai_eval.supported_models import SupportedModels
+from ai_eval.supported_models import SupportedModels, resolve_model
 from ai_eval.llm_services import CustomLLMService
 from ai_eval.backends.factory import BackendFactory
 from ai_eval.backends.judge0 import Judge0Backend
@@ -1770,3 +1770,60 @@ def test_coding_studio_lock_payload_unsets_judge0_lock_flag_without_runtime_key(
             patch("ai_eval.base.get_site_configuration_value", return_value=None):
         payload = block._studio_lock_metadata()
         assert payload["lock_judge0_api_key"] is False
+
+
+# Legacy model compatibility shim: activities saved with a provider-retired model id
+# (Anthropic's claude-sonnet-4-20250514) keep working by resolving to the replacement
+# (claude-sonnet-4-6) at runtime, with no course-content edits.
+LEGACY_CLAUDE = "claude-sonnet-4-20250514"
+
+
+def test_resolve_model_maps_legacy_to_replacement():
+    """resolve_model should map the retired id, and pass through everything else."""
+    assert resolve_model(LEGACY_CLAUDE) == "claude-sonnet-4-6"
+    assert resolve_model("claude-sonnet-4-6") == "claude-sonnet-4-6"
+    assert resolve_model(SupportedModels.GPT4O.value) == SupportedModels.GPT4O.value
+    assert resolve_model("some/custom-model") == "some/custom-model"
+
+
+def test_effective_model_resolves_legacy_value(shortanswer_block_data):
+    """A block saved with the legacy Claude id should resolve to the replacement."""
+    legacy = ShortAnswerAIEvalXBlock(
+        ToyRuntime(), DictFieldData({**shortanswer_block_data, "model": LEGACY_CLAUDE}), None
+    )
+    current = ShortAnswerAIEvalXBlock(
+        ToyRuntime(), DictFieldData({**shortanswer_block_data, "model": "claude-sonnet-4-6"}), None
+    )
+    assert legacy.effective_model == "claude-sonnet-4-6"
+    assert current.effective_model == "claude-sonnet-4-6"
+
+
+def test_get_llm_response_calls_provider_with_resolved_model(shortanswer_block_data):
+    """The provider call must use the resolved id, not the retired one stored on the block."""
+    block = ShortAnswerAIEvalXBlock(
+        ToyRuntime(),
+        DictFieldData({**shortanswer_block_data, "model": LEGACY_CLAUDE, "model_api_key": "k"}),
+        None,
+    )
+    with patch("ai_eval.base.get_llm_response", return_value=("ok", None)) as mock_llm, \
+            patch("ai_eval.base.get_site_configuration_value", return_value=None):
+        block.get_llm_response([{"role": "user", "content": "hi"}])
+    assert mock_llm.call_args.args[0] == "claude-sonnet-4-6"
+
+
+def test_model_config_key_resolves_legacy_value():
+    """Per-model API-key config lookups for a legacy id reuse the CLAUDE_SONNET key name."""
+    assert (
+        AIEvalXBlock._get_model_config_key(LEGACY_CLAUDE, "api_key") == "CLAUDE_SONNET_API_KEY"
+    )
+    assert (
+        AIEvalXBlock._get_model_config_key("claude-sonnet-4-6", "api_key") == "CLAUDE_SONNET_API_KEY"
+    )
+
+
+def test_coach_legacy_model_still_matches_claude_branch(coach_block_data):
+    """The Coach dummy-user-turn branch must still fire for legacy-configured blocks."""
+    block = CoachAIEvalXBlock(
+        ToyRuntime(), DictFieldData({**coach_block_data, "model": LEGACY_CLAUDE}), None
+    )
+    assert block.effective_model == SupportedModels.CLAUDE_SONNET.value


### PR DESCRIPTION
## Description
The AI-evaluation XBlocks offered Anthropic's claude-sonnet-4-20250514 (Claude Sonnet 4) as a selectable model. Anthropic has retired that model, so any request to it now fails at the provider and learners get an error instead of an AI response.

This PR:
- Switches the supported Claude model to claude-sonnet-4-6 (Claude Sonnet 4.6), Anthropic's official drop-in replacement.
- Adds a backwards-compatibility shim that resolves the retired id to its replacement at the point of use.

## Supporting Information
OpenCraft's Internal Jira task: [BB-10960](https://tasks.opencraft.com/browse/BB-10960)

## Testing Instructions
1. New activity: Add or edit an AI-eval block in Studio, open settings, confirm the model dropdown lists claude-sonnet-4-6 (and no longer lists claude-sonnet-4-20250514). Select it, provide a valid Anthropic API key, and save.
2. In the LMS, submit a learner response and confirm an AI reply is returned.
3. Legacy activity (the shim): Take a block whose stored model is still claude-sonnet-4-20250514, do not re-select the model, and submit a learner response in the LMS. Confirm it succeeds - the request is served by claude-sonnet-4-6 with no edit to the block.