### PR TITLE
Fix model field using Scope= instead of scope=

### DIFF
--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -47,7 +47,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         values=[
             {"display_name": model, "value": model} for model in SupportedModels.list()
         ],
-        Scope=Scope.settings,
+        scope=Scope.settings,
         default=SupportedModels.GPT4O.value,
     )
 


### PR DESCRIPTION
The `model` field in `AIEvalXBlock` is declared with `Scope=Scope.settings` (capital `Scope=`) instead of `scope=`. Since `Field` folds any unrecognized keyword into `**kwargs` (that's how `multiline_editor=` works on the neighbouring fields), the capitalized one is silently ignored and the field falls back to the default `Scope.content`. So `model` ends up at DEFINITION scope while `evaluation_prompt`, `question`, `model_api_key` and `model_api_url` are all USAGE-scoped.

Switched it to lowercase `scope=Scope.settings` so it's persisted the same way as the other editable fields.

Small one, but figured it was worth flagging since it's easy to miss. Thanks!
