### PR TITLE
Fix field scope typo storing model and language in definition scope

### DIFF
--- a/ai_eval/base.py
+++ b/ai_eval/base.py
@@ -47,7 +47,7 @@ class AIEvalXBlock(StudioEditableXBlockMixin, XBlock):
         values=[
             {"display_name": model, "value": model} for model in SupportedModels.list()
         ],
-        Scope=Scope.settings,
+        scope=Scope.settings,
         default=SupportedModels.GPT4O.value,
     )
 

--- a/ai_eval/coding_ai_eval.py
+++ b/ai_eval/coding_ai_eval.py
@@ -60,7 +60,7 @@ class CodingAIEvalXBlock(AIEvalXBlock):
             for language in SUPPORTED_LANGUAGE_MAP
         ],
         default=LanguageLabels.Python,
-        Scope=Scope.settings,
+        scope=Scope.settings,
     )
     messages = Dict(
         help=_("Dictionary with messages"),

--- a/ai_eval/tests/test_ai_eval.py
+++ b/ai_eval/tests/test_ai_eval.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 from xblock.exceptions import JsonHandlerError
 from xblock.field_data import DictFieldData
+from xblock.fields import Scope
 from xblock.test.toy_runtime import ToyRuntime
 
 from ai_eval import CodingAIEvalXBlock, ShortAnswerAIEvalXBlock
@@ -191,3 +192,22 @@ def test_get_model_api_url_delegates(mock_get_config, ai_eval_block):
     """Test that get_model_api_url delegates to _get_model_config_value."""
     assert ai_eval_block.get_model_api_url() == "test-url"
     mock_get_config.assert_called_once_with("api_url", None)
+
+
+@pytest.mark.parametrize(
+    "block_class, field_name",
+    [
+        (AIEvalXBlock, "model"),
+        (CodingAIEvalXBlock, "model"),
+        (ShortAnswerAIEvalXBlock, "model"),
+        (CodingAIEvalXBlock, "language"),
+    ],
+)
+def test_author_fields_use_settings_scope(block_class, field_name):
+    """Author-configured fields must use settings (usage) scope.
+
+    A capital ``Scope=`` keyword is not the field's ``scope`` argument, so it
+    was silently ignored and these fields fell back to the default
+    ``Scope.content`` (definition scope), unlike every sibling field.
+    """
+    assert block_class.fields[field_name].scope == Scope.settings


### PR DESCRIPTION
## Problem

Two author-configured fields are declared with `Scope=Scope.settings` using a capital `S`:

- `model` in `AIEvalXBlock` (`ai_eval/base.py`)
- `language` in `CodingAIEvalXBlock` (`ai_eval/coding_ai_eval.py`)

`Scope=` is not the XBlock field's `scope` argument. XBlock accepts arbitrary extra keyword arguments and silently ignores unknown ones, so the intended scope never gets applied. Both fields fall back to the field default `Scope.content` (user=NONE, block=DEFINITION), while every other field in these classes uses `scope=Scope.settings` (block=USAGE).

I verified this against `XBlock==6.2.0`:

```
String(Scope=Scope.settings).scope -> Scope.content   (BlockScope.DEFINITION)
String(scope=Scope.settings).scope -> Scope.settings  (BlockScope.USAGE)
```

So the selected AI model and programming language are stored on the block **definition** instead of per **usage**. That is inconsistent with the other settings and changes how the values are serialized on OLX export/import and shared when a block is reused from a content library.

## Fix

Change `Scope=` to `scope=` on both fields. No other behavior changes.

## Tests

Added a parametrized regression test (`test_author_fields_use_settings_scope`) asserting that `model` (on all three block classes) and `language` use `Scope.settings`. Confirmed it fails on the current code (scope is `content`) and passes after the fix.